### PR TITLE
Review follow-ups (batch 1): token atomicity, game_end dedup, teardown, mid-clear snapshot

### DIFF
--- a/apps/mobile/lib/domain/tetris/tetris_engine.dart
+++ b/apps/mobile/lib/domain/tetris/tetris_engine.dart
@@ -352,6 +352,15 @@ class TetrisEngine {
     _clearTimerMs = _clearDelayMs;
   }
 
+  /// Immediately completes a pending line-clear (collapse + spawn), skipping the
+  /// remaining animation delay. Used before persisting so a snapshot taken
+  /// during the clear window reflects the committed post-clear state.
+  void flushPendingClear() {
+    if (_clearingRows.isNotEmpty) {
+      _finishClear();
+    }
+  }
+
   void _finishClear() {
     _board = _board.clearFullRows().board;
     _clearingRows = <int>[];

--- a/apps/mobile/lib/features/game_loop/application/game_loop_controller.dart
+++ b/apps/mobile/lib/features/game_loop/application/game_loop_controller.dart
@@ -125,6 +125,7 @@ class GameLoopController {
   String _rewardedToolsUnlimitedSku = 'utility_tools_pass';
   bool _bannerRequestedInSession = false;
   bool _rewardedReviveUsedInCurrentGame = false;
+  bool _gameEndEmitted = false;
   int _currentGameNumber = 0;
   int? _lastInterstitialRound;
   DateTime? _sessionStartedAt;
@@ -248,6 +249,7 @@ class GameLoopController {
     _observabilityTracker.onRoundStarted();
     _gameStartedAt = _nowUtc();
     _rewardedReviveUsedInCurrentGame = false;
+    _gameEndEmitted = false;
     _undoHistory.clear();
     final int nextGamesPlayed = snapshot != null ? snapshot.gamesPlayed : state.gamesPlayed + 1;
     final bool shouldShowOnboarding =
@@ -561,10 +563,15 @@ class GameLoopController {
           resetOnboarding: true,
         );
       }
-      await _trackGameEnd(
-        reason: 'no_valid_moves',
-        score: nextScore.totalScore,
-      );
+      // Emit game_end at most once per round_id: a rewarded revive resumes the
+      // same round, so a post-revive game-over must not duplicate the event.
+      if (!_gameEndEmitted) {
+        _gameEndEmitted = true;
+        await _trackGameEnd(
+          reason: 'no_valid_moves',
+          score: nextScore.totalScore,
+        );
+      }
       await gameSessionRepository.clearSnapshot();
       await _maybeShowInterstitialAfterGameEnd();
     }

--- a/apps/mobile/lib/features/tetris/application/tetris_controller.dart
+++ b/apps/mobile/lib/features/tetris/application/tetris_controller.dart
@@ -43,6 +43,8 @@ class TetrisController extends ChangeNotifier {
   TetrisEngine _engine;
   bool _started = false;
   bool _reviveUsed = false;
+  bool _gameEndEmitted = false;
+  bool _disposed = false;
   int _bestScore = 0;
   String _roundId = 'tetris_0';
   DateTime? _startedAt;
@@ -93,7 +95,7 @@ class TetrisController extends ChangeNotifier {
 
   /// Continue after game over by clearing the top of the stack (once per run).
   void revive() {
-    if (!_engine.isGameOver || _reviveUsed) {
+    if (_disposed || !_engine.isGameOver || _reviveUsed) {
       return;
     }
     if (!_engine.reviveClearTop()) {
@@ -112,7 +114,7 @@ class TetrisController extends ChangeNotifier {
   }
 
   void input(TetrisInput intent) {
-    if (_engine.isGameOver) {
+    if (_disposed || _engine.isGameOver) {
       return;
     }
     _engine.applyInput(intent);
@@ -122,7 +124,7 @@ class TetrisController extends ChangeNotifier {
 
   /// Advances gravity/lock by [delta] (driven from the Flame frame loop).
   void tick(Duration delta) {
-    if (!_started || _engine.isGameOver) {
+    if (_disposed || !_started || _engine.isGameOver) {
       return;
     }
     _engine.tick(delta);
@@ -134,13 +136,23 @@ class TetrisController extends ChangeNotifier {
   /// Persists the in-progress game (call on app pause). No-op when idle.
   void saveActiveGame() {
     final TetrisSessionStore? store = _store;
-    if (store == null || !_engine.hasActiveGame) {
+    if (store == null) {
+      return;
+    }
+    // Finalize a pending line-clear so the snapshot reflects committed state;
+    // otherwise the lock + cleared lines + score in the ~120ms clear window
+    // would be lost on resume.
+    if (_engine.isClearing) {
+      _engine.flushPendingClear();
+    }
+    if (!_engine.hasActiveGame) {
       return;
     }
     unawaited(store.saveSnapshot(_engine.toSnapshot()));
   }
 
   void _beginRound() {
+    _gameEndEmitted = false;
     _startedAt = DateTime.now();
     _roundId = 'tetris_${_startedAt!.microsecondsSinceEpoch}';
     _track('game_start', <String, Object?>{
@@ -223,18 +235,23 @@ class TetrisController extends ChangeNotifier {
     }
     unawaited(_store?.saveBestScore(finalScore));
     unawaited(_store?.clearSnapshot());
-    final int duration = _startedAt == null
-        ? 0
-        : DateTime.now().difference(_startedAt!).inSeconds;
-    _track('game_end', <String, Object?>{
-      'round_id': _roundId,
-      'end_reason': 'top_out',
-      'score': finalScore,
-      'duration_sec': duration,
-      'level': _engine.level,
-      'lines': _engine.linesCleared,
-      'game_id': 'tetris',
-    });
+    // Emit game_end at most once per round_id: a revive resumes the same round,
+    // so a post-revive top-out must not duplicate the event.
+    if (!_gameEndEmitted) {
+      _gameEndEmitted = true;
+      final int duration = _startedAt == null
+          ? 0
+          : DateTime.now().difference(_startedAt!).inSeconds;
+      _track('game_end', <String, Object?>{
+        'round_id': _roundId,
+        'end_reason': 'top_out',
+        'score': finalScore,
+        'duration_sec': duration,
+        'level': _engine.level,
+        'lines': _engine.linesCleared,
+        'game_id': 'tetris',
+      });
+    }
     _onGameOver?.call();
   }
 
@@ -244,5 +261,12 @@ class TetrisController extends ChangeNotifier {
       return;
     }
     unawaited(analytics.track(name, params: params));
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    onVisualEvent = null;
+    super.dispose();
   }
 }

--- a/apps/mobile/lib/features/tetris/presentation/tetris_screen.dart
+++ b/apps/mobile/lib/features/tetris/presentation/tetris_screen.dart
@@ -63,6 +63,7 @@ class _TetrisScreenState extends State<TetrisScreen>
   void dispose() {
     _isDisposed = true;
     WidgetsBinding.instance.removeObserver(this);
+    _game.pauseEngine();
     unawaited(_music.stop());
     _controller.dispose();
     super.dispose();

--- a/apps/mobile/test/unit/domain/tetris/tetris_engine_test.dart
+++ b/apps/mobile/test/unit/domain/tetris/tetris_engine_test.dart
@@ -115,6 +115,35 @@ void main() {
       expect(engine.linesCleared, 1);
     });
 
+    test('flushPendingClear collapses a pending clear immediately', () {
+      // Same setup as the clearing test; flush instead of waiting the delay
+      // (this is what saveActiveGame does so a mid-clear snapshot is committed).
+      final List<TetrominoType?> cells =
+          List<TetrominoType?>.filled(4 * 8, null);
+      int idx(int x, int y) => (y * 4) + x;
+      cells[idx(1, 7)] = TetrominoType.l;
+      cells[idx(2, 7)] = TetrominoType.l;
+      cells[idx(3, 7)] = TetrominoType.l;
+      final TetrisEngine engine = TetrisEngine(width: 4, height: 8)
+        ..restore(<String, Object?>{
+          'board': TetrisBoard(width: 4, height: 8, cells: cells).toJson(),
+          'active': const FallingPiece(
+            type: TetrominoType.i,
+            rotationIndex: 1,
+            originX: -2,
+            originY: 0,
+          ).toJson(),
+        });
+
+      engine.applyInput(TetrisInput.hardDrop);
+      expect(engine.isClearing, isTrue);
+
+      engine.flushPendingClear();
+      expect(engine.isClearing, isFalse);
+      expect(engine.active, isNotNull);
+      expect(engine.linesCleared, 1);
+    });
+
     test('perfect clear (all-clear) emits a bonus event', () {
       // Empty 4-wide board; a horizontal I hard-drops to fill + clear the only
       // occupied row, emptying the board → Perfect Clear.

--- a/docs/DOCS_CHANGELOG.md
+++ b/docs/DOCS_CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Append one dated line per status-changing documentation merge. The canonical status of the product is [roadmap/05_IMPLEMENTATION_STATUS.md](roadmap/05_IMPLEMENTATION_STATUS.md); this log records *when and why* it (and other load-bearing docs) changed. Supersedes the archived `archive/root/DOCS_CHANGELOG_2026-02-26.md`.
 
+## 2026-06-21 (Review follow-ups — batch 1)
+- Closed the 4 priority follow-ups from the PR #42 review: (1) billing token binding is now atomic (check inside `runTransaction` in `verifyPurchase`); (2) `game_end` de-duplicated per round in both Tetris and Classic (`_gameEndEmitted` guard); (3) mid-clear snapshot no longer loses the lock/score (`TetrisEngine.flushPendingClear` invoked from `saveActiveGame`); (4) Tetris teardown hardened (controller `_disposed` guard + `onVisualEvent` cleared + Flame loop paused on dispose). `flutter analyze` clean; 163 tests. Details: [audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md](audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md).
+
 ## 2026-06-21 (Pre-merge review of PR #42)
 - Multi-agent pre-merge review (5 dimensions + adversarial verification). Verdict: **GO_WITH_NITS** — no merge blockers; branch analyze-clean, 162 tests, CI green. Confirmed P1/P2 follow-ups captured in [audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md](audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md) (top priorities: billing token atomicity in `verifyPurchase`, and the duplicate `game_end` after revive — affects both Tetris and Classic). Two findings were adversarially refuted/downgraded (music pause-on-background works; the music "race" is a deterministic cosmetic pop-back issue).
 

--- a/docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md
+++ b/docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md
@@ -4,6 +4,15 @@ Date: 2026-06-21
 Source: multi-agent pre-merge review of `feat/p0-fixes-and-tetris-domain` (5 review dimensions → adversarial verification of 12 P0/P1 findings → verdict).
 Verdict: **GO_WITH_NITS** — no merge blockers (`mustFix` empty). Branch is `flutter analyze`-clean, 162 tests pass, CI green. Items below are tracked follow-ups to do *after* the merge; none break a core game/payment flow or crash.
 
+## Resolved — batch 1 (2026-06-21)
+Done on branch `fix/review-followups-p1` (analyze clean, 163 tests):
+- ✅ **#1 Billing token atomicity** — the cross-account/replay check now runs inside `runTransaction` (`tx.get(tokenRef)` before the writes) in `infra/cloud_functions/functions/index.js`.
+- ✅ **#2 Duplicate `game_end` after revive** — `game_end` is now emitted at most once per round via a `_gameEndEmitted` guard, in **both** Tetris (`tetris_controller.dart`) and Classic (`game_loop_controller.dart`, reset in `startNewGame`).
+- ✅ **#3 Snapshot lost during the clear window** — `saveActiveGame()` now calls `engine.flushPendingClear()` (collapse + commit) before snapshotting; added `TetrisEngine.flushPendingClear` + test.
+- ✅ **#5 Tetris teardown** — `TetrisController` is now disposed-guarded (`_disposed` short-circuits tick/input/revive) and clears `onVisualEvent` on dispose; `TetrisScreen.dispose()` pauses the Flame loop before disposing.
+
+Remaining items (#4, #6–#13, perf/polish, test gaps) are still open below.
+
 ## Confirmed — prioritize first
 1. **Billing token binding is not atomic (TOCTOU).** `verifyPurchase` reads the token doc with a plain `get()` outside the transaction and never re-reads it inside `runTransaction`, so two concurrent calls with the same `purchaseToken` under different UIDs can both grant. Move the existence/uid check inside `runTransaction` (`tx.get` before `tx.set`). `infra/cloud_functions/functions/index.js:60-116`. (Function not yet deployed — fix before deploy.)
 2. **Duplicate `game_end` after revive.** `revive()` does not call `_beginRound()`, so a post-revive top-out emits a second `game_end` with the same `round_id` → one `game_start`, two `game_end` per round (skews funnels). Add a `_gameEndEmitted` guard reset only in `_beginRound`, or a `post_revive` flag. `tetris_controller.dart` (`revive`/`_onGameEnd`). **Note (verified):** Classic's `useRewardedRevive` has the same exposure — fix both.

--- a/infra/cloud_functions/functions/index.js
+++ b/infra/cloud_functions/functions/index.js
@@ -55,15 +55,10 @@ exports.verifyPurchase = onCall({ region: 'us-central1' }, async (request) => {
     throw new HttpsError('invalid-argument', 'Missing purchaseToken.');
   }
 
-  // Replay / cross-account protection: a purchase token may only ever belong
-  // to one account.
   const tokenRef = db.collection('purchaseTokens').doc(purchaseToken);
-  const tokenSnap = await tokenRef.get();
-  if (tokenSnap.exists && tokenSnap.get('uid') !== uid) {
-    throw new HttpsError('permission-denied', 'Token is bound to another account.');
-  }
 
-  // Verify the token against the Google Play Developer API.
+  // Verify the token against the Google Play Developer API. No Firestore I/O
+  // here, so it stays outside the transaction below.
   let purchase;
   try {
     const client = await playAuth.getClient();
@@ -92,28 +87,48 @@ exports.verifyPurchase = onCall({ region: 'us-central1' }, async (request) => {
     };
   }
 
+  // Grant + bind atomically. The replay / cross-account check (a purchase token
+  // may only ever belong to one account) is read INSIDE the transaction so two
+  // concurrent calls presenting the same token under different UIDs cannot both
+  // bind it (TOCTOU-safe).
   const entRef = db.collection('entitlements').doc(uid);
-  await db.runTransaction(async (tx) => {
-    tx.set(
-      entRef,
-      {
-        productIds: FieldValue.arrayUnion(productId),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
-    tx.set(
-      tokenRef,
-      {
-        uid,
-        productId,
-        source,
-        orderId: purchase.orderId || null,
-        verifiedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
-  });
+  try {
+    await db.runTransaction(async (tx) => {
+      const tokenSnap = await tx.get(tokenRef);
+      if (tokenSnap.exists && tokenSnap.get('uid') !== uid) {
+        const err = new Error('token_bound_other_account');
+        err.boundOtherAccount = true;
+        throw err;
+      }
+      tx.set(
+        entRef,
+        {
+          productIds: FieldValue.arrayUnion(productId),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+      tx.set(
+        tokenRef,
+        {
+          uid,
+          productId,
+          source,
+          orderId: purchase.orderId || null,
+          verifiedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+    });
+  } catch (error) {
+    if (error && error.boundOtherAccount) {
+      throw new HttpsError(
+        'permission-denied',
+        'Token is bound to another account.',
+      );
+    }
+    throw error;
+  }
 
   const entSnap = await entRef.get();
   const entitlements =


### PR DESCRIPTION
## Summary
Batch 1 of the PR #42 pre-merge review follow-ups (the priority items). `flutter analyze` clean; **163 tests** pass.

- **Billing token atomicity (TOCTOU).** The cross-account/replay check now runs **inside** `verifyPurchase`'s `runTransaction` (`tx.get(tokenRef)` before the writes), so two concurrent calls can't both bind the same `purchaseToken` to different accounts. `infra/cloud_functions/functions/index.js`.
- **`game_end` de-dup.** A revive resumes the same round; `game_end` is now emitted at most once per round via a `_gameEndEmitted` guard — in **both** Tetris (`tetris_controller.dart`) and Classic (`game_loop_controller.dart`, reset in `startNewGame`). Fixes the funnel double-count.
- **Mid-clear snapshot loss.** `saveActiveGame()` now calls `TetrisEngine.flushPendingClear()` (collapse + commit) before snapshotting, so backgrounding/killing during the ~120 ms line-clear window no longer loses the lock + cleared lines + score. + unit test.
- **Tetris teardown.** `TetrisController` is disposed-guarded (`_disposed` short-circuits tick/input/revive) and clears `onVisualEvent` on dispose; `TetrisScreen.dispose()` pauses the Flame loop first — removes the latent post-dispose `notifyListeners` path.

Tracked in `docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md` (remaining items #4, #6–#13 + perf/test-gaps still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
