### PR TITLE
Review follow-ups batch 2: perfect-clear, lock-flash, lock-reset, restore validation, analytics

### DIFF
--- a/apps/mobile/lib/data/analytics/analytics_schema_validator.dart
+++ b/apps/mobile/lib/data/analytics/analytics_schema_validator.dart
@@ -160,6 +160,7 @@ class AnalyticsSchemaValidator {
         'rack_size',
         'ux_variant',
         'difficulty_variant',
+        'resumed',
       },
     ),
     'move_made': AnalyticsEventSchema(

--- a/apps/mobile/lib/domain/tetris/tetris_engine.dart
+++ b/apps/mobile/lib/domain/tetris/tetris_engine.dart
@@ -96,6 +96,11 @@ class TetrisEngine {
   int _lockResets = 0;
   bool _lastActionWasRotation = false;
 
+  /// Visible cells of the most recently locked piece, captured at lock time so
+  /// the view can flash exactly where it landed (even on a hard drop, before a
+  /// render at the landed position).
+  List<TCell> _lastLockedCells = <TCell>[];
+
   final List<TetrisEvent> _events = <TetrisEvent>[];
 
   // ── Public state ──
@@ -111,6 +116,7 @@ class TetrisEngine {
   bool get canHold => _canHold;
   bool get isClearing => _clearingRows.isNotEmpty;
   List<int> get clearingRows => List<int>.unmodifiable(_clearingRows);
+  List<TCell> get lastLockedCells => List<TCell>.unmodifiable(_lastLockedCells);
   double get clearProgress => _clearDelayMs <= 0
       ? 1
       : (1 - (_clearTimerMs / _clearDelayMs)).clamp(0, 1).toDouble();
@@ -151,6 +157,10 @@ class TetrisEngine {
     _lockAccumMs = 0;
     _lockResets = 0;
     _lastActionWasRotation = false;
+    // Reset run-chain bonuses: the revive breaks any combo / back-to-back so a
+    // stale multiplier can't carry across the gap.
+    _combo = -1;
+    _backToBack = false;
     _canHold = true;
     _spawnNext();
     return !_gameOver;
@@ -222,7 +232,7 @@ class TetrisEngine {
     _gravityAccumMs += ms;
     while (_gravityAccumMs >= intervalMs) {
       _gravityAccumMs -= intervalMs;
-      if (!_tryMove(0, 1)) {
+      if (!_tryMove(0, 1, isGravity: true)) {
         break;
       }
     }
@@ -247,7 +257,7 @@ class TetrisEngine {
     return _board.collides(piece.movedBy(0, 1));
   }
 
-  bool _tryMove(int dx, int dy) {
+  bool _tryMove(int dx, int dy, {bool isGravity = false}) {
     final FallingPiece? piece = _active;
     if (piece == null) {
       return false;
@@ -261,7 +271,11 @@ class TetrisEngine {
     if (dx != 0) {
       _events.add(const TetrisEvent(TetrisEventType.move));
     }
-    _onPieceShifted();
+    // Gravity-driven descent must not consume a lock-delay reset; only
+    // player-initiated moves/rotations do (guideline "infinity with cap").
+    if (!isGravity) {
+      _onPieceShifted();
+    }
     return true;
   }
 
@@ -322,9 +336,14 @@ class TetrisEngine {
             ? _detectTSpin(piece)
             : TSpinType.none;
 
-    // Top-out: a piece that locks entirely above the visible field ends the run.
-    final bool anyVisible =
-        piece.absoluteCells().any((TCell c) => c.y >= 0);
+    // Capture the locked cells (visible part) so the view can flash exactly
+    // where the piece landed, even on a hard drop.
+    final List<TCell> lockedCells = piece.absoluteCells();
+    final bool anyVisible = lockedCells.any((TCell c) => c.y >= 0);
+    _lastLockedCells = <TCell>[
+      for (final TCell c in lockedCells)
+        if (c.y >= 0) c,
+    ];
     _board = _board.lock(piece);
     _events.add(const TetrisEvent(TetrisEventType.lock));
     _active = null;
@@ -340,6 +359,7 @@ class TetrisEngine {
     if (full.isEmpty || _clearDelayMs <= 0) {
       if (full.isNotEmpty) {
         _board = _board.clearFullRows().board;
+        _awardPerfectClearIfEmpty();
       }
       _canHold = true;
       _spawnNext();
@@ -365,14 +385,19 @@ class TetrisEngine {
     _board = _board.clearFullRows().board;
     _clearingRows = <int>[];
     _clearTimerMs = 0;
+    _awardPerfectClearIfEmpty();
+    _canHold = true;
+    _spawnNext();
+  }
+
+  /// Perfect Clear (All-Clear): the clear emptied the board. Awards a bonus and
+  /// emits the event. Called from both the delayed and the zero-delay paths.
+  void _awardPerfectClearIfEmpty() {
     if (_board.isEmpty) {
-      // Perfect Clear (All-Clear): board emptied by the clear.
       final int bonus = 1000 * _level;
       _score += bonus;
       _events.add(TetrisEvent(TetrisEventType.perfectClear, 0, bonus));
     }
-    _canHold = true;
-    _spawnNext();
   }
 
   void _applyScoring(int rows, TSpinType spin) {
@@ -540,6 +565,12 @@ class TetrisEngine {
     _lockResets = 0;
     _lastActionWasRotation = false;
     if (_active == null) {
+      _spawnNext();
+    } else if (_board.collides(_active!)) {
+      // Corrupt/incompatible snapshot: the restored piece overlaps the board.
+      // Drop it and re-spawn cleanly rather than resuming into a collision; if
+      // there is no room to spawn either, that surfaces as a normal block-out.
+      _active = null;
       _spawnNext();
     }
   }

--- a/apps/mobile/lib/features/game_loop/application/game_loop_controller.dart
+++ b/apps/mobile/lib/features/game_loop/application/game_loop_controller.dart
@@ -385,7 +385,7 @@ class GameLoopController {
       await analyticsTracker.track(
         'move_rejected',
         params: <String, Object?>{
-          'reason': placeResult.failureReason,
+          'reason': placeResult.failureReason ?? 'invalid_move',
           'piece_id': move.piece.id,
           'anchor_x': move.anchorX,
           'anchor_y': move.anchorY,

--- a/apps/mobile/lib/features/tetris/application/tetris_controller.dart
+++ b/apps/mobile/lib/features/tetris/application/tetris_controller.dart
@@ -73,12 +73,16 @@ class TetrisController extends ChangeNotifier {
     _reviveUsed = false;
     _bestScore = await (_store?.loadBestScore() ?? Future<int>.value(0));
     final Map<String, Object?>? snapshot = await _store?.loadSnapshot();
+    final bool resumed = snapshot != null;
     if (snapshot != null) {
       _engine.restore(snapshot);
+      // The once-per-run revive flag is persisted with the snapshot so
+      // backgrounding after a revive can't grant a second one.
+      _reviveUsed = snapshot['revive_used'] as bool? ?? false;
     } else {
       _engine.start();
     }
-    _beginRound();
+    _beginRound(resumed: resumed);
     _consumeEvents();
     notifyListeners();
   }
@@ -148,10 +152,13 @@ class TetrisController extends ChangeNotifier {
     if (!_engine.hasActiveGame) {
       return;
     }
-    unawaited(store.saveSnapshot(_engine.toSnapshot()));
+    unawaited(store.saveSnapshot(<String, Object?>{
+      ..._engine.toSnapshot(),
+      'revive_used': _reviveUsed,
+    }));
   }
 
-  void _beginRound() {
+  void _beginRound({bool resumed = false}) {
     _gameEndEmitted = false;
     _startedAt = DateTime.now();
     _roundId = 'tetris_${_startedAt!.microsecondsSinceEpoch}';
@@ -160,6 +167,7 @@ class TetrisController extends ChangeNotifier {
       'mode': 'tetris',
       'config_version': 'tetris_v1',
       'game_id': 'tetris',
+      'resumed': resumed,
     });
   }
 

--- a/apps/mobile/lib/features/tetris/presentation/tetris_game.dart
+++ b/apps/mobile/lib/features/tetris/presentation/tetris_game.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -40,7 +41,6 @@ class TetrisFlameGame extends FlameGame {
   double _scorePopElapsed = 0;
   double _clock = 0; // free-running clock for pulsing effects
   final BurstField _burst = BurstField();
-  final List<TCell> _lastActiveCells = <TCell>[];
   final List<_LockFlash> _lockFlashes = <_LockFlash>[];
 
   // Last computed board layout (screen space), so event handlers can place
@@ -49,6 +49,14 @@ class TetrisFlameGame extends FlameGame {
   double _loy = 0;
   double _lcell = 0;
 
+  // Cached static board background (gradient + grid + border), recorded at a
+  // local origin and re-recorded only when the board geometry changes. Avoids
+  // rebuilding gradient shaders and drawing every grid line each frame.
+  ui.Picture? _bgPicture;
+  double _bgW = -1;
+  double _bgH = -1;
+  double _bgCell = -1;
+
   @override
   Color backgroundColor() => const Color(0x00000000);
 
@@ -56,6 +64,13 @@ class TetrisFlameGame extends FlameGame {
   Future<void> onLoad() async {
     controller.onVisualEvent = _onVisualEvent;
     await super.onLoad();
+  }
+
+  @override
+  void onRemove() {
+    _bgPicture?.dispose();
+    _bgPicture = null;
+    super.onRemove();
   }
 
   void _onVisualEvent(TetrisEvent event) {
@@ -99,7 +114,11 @@ class TetrisFlameGame extends FlameGame {
         _shake = math.max(_shake, 0.8);
         break;
       case TetrisEventType.lock:
-        for (final TCell c in _lastActiveCells) {
+        // Flash exactly where the piece locked. Read the engine's captured
+        // locked cells (not the last rendered active cells) so a hard drop —
+        // which locks before any render at the landed position — flashes the
+        // landing spot, not the stale mid-air position.
+        for (final TCell c in controller.engine.lastLockedCells) {
           _lockFlashes.add(_LockFlash(c.x, c.y));
         }
         break;
@@ -255,13 +274,11 @@ class TetrisFlameGame extends FlameGame {
         }
       }
     }
-    _lastActiveCells.clear();
     if (active != null) {
       final Color color = tetrominoColors[active.type]!;
       for (final TCell c in active.absoluteCells()) {
         if (c.y >= 0) {
           _paintCell(canvas, ox, oy, c.x, c.y, cell, color);
-          _lastActiveCells.add(c);
         }
       }
     }
@@ -426,7 +443,35 @@ class TetrisFlameGame extends FlameGame {
     int cols,
     int rows,
   ) {
-    final Rect rect = Rect.fromLTWH(ox, oy, boardW, boardH);
+    if (_bgPicture == null ||
+        _bgW != boardW ||
+        _bgH != boardH ||
+        _bgCell != cell) {
+      final ui.PictureRecorder recorder = ui.PictureRecorder();
+      _paintBackground(Canvas(recorder), boardW, boardH, cell, cols, rows);
+      _bgPicture?.dispose();
+      _bgPicture = recorder.endRecording();
+      _bgW = boardW;
+      _bgH = boardH;
+      _bgCell = cell;
+    }
+    canvas.save();
+    canvas.translate(ox, oy);
+    canvas.drawPicture(_bgPicture!);
+    canvas.restore();
+  }
+
+  /// Paints the static board chrome at a local (0,0) origin (the caller
+  /// translates). Kept separate so it can be recorded into a cached [ui.Picture].
+  void _paintBackground(
+    Canvas canvas,
+    double boardW,
+    double boardH,
+    double cell,
+    int cols,
+    int rows,
+  ) {
+    final Rect rect = Rect.fromLTWH(0, 0, boardW, boardH);
     final RRect rr = RRect.fromRectAndRadius(rect, const Radius.circular(14));
 
     final Paint bg = Paint()
@@ -442,12 +487,12 @@ class TetrisFlameGame extends FlameGame {
       ..strokeWidth = 1
       ..color = const Color(0x2278B5DE);
     for (int x = 1; x < cols; x++) {
-      final double gx = ox + (x * cell);
-      canvas.drawLine(Offset(gx, oy), Offset(gx, oy + boardH), grid);
+      final double gx = x * cell;
+      canvas.drawLine(Offset(gx, 0), Offset(gx, boardH), grid);
     }
     for (int y = 1; y < rows; y++) {
-      final double gy = oy + (y * cell);
-      canvas.drawLine(Offset(ox, gy), Offset(ox + boardW, gy), grid);
+      final double gy = y * cell;
+      canvas.drawLine(Offset(0, gy), Offset(boardW, gy), grid);
     }
 
     final Paint border = Paint()

--- a/apps/mobile/test/unit/domain/tetris/tetris_engine_test.dart
+++ b/apps/mobile/test/unit/domain/tetris/tetris_engine_test.dart
@@ -197,5 +197,125 @@ void main() {
       expect(restored.active, isNotNull);
       expect(filledCells(restored.board), filledCells(engine.board));
     });
+
+    test('perfect clear is awarded on the zero-delay (instant) path', () {
+      // With no clear animation delay the lock collapses immediately; the
+      // all-clear bonus must still fire (regression for the fast-path bypass).
+      final TetrisEngine engine =
+          TetrisEngine(width: 4, height: 8, lineClearDelay: Duration.zero)
+            ..restore(<String, Object?>{
+              'board': TetrisBoard(width: 4, height: 8).toJson(),
+              'active': const FallingPiece(
+                type: TetrominoType.i,
+                rotationIndex: 0,
+                originX: 0,
+                originY: 0,
+              ).toJson(),
+            });
+      engine.drainEvents();
+
+      engine.applyInput(TetrisInput.hardDrop); // no tick — collapses instantly
+
+      expect(engine.isClearing, isFalse);
+      expect(engine.board.isEmpty, isTrue);
+      expect(
+        engine.drainEvents().map((TetrisEvent e) => e.type),
+        contains(TetrisEventType.perfectClear),
+      );
+    });
+
+    test('rotating a T into a 3-corner slot is detected as a T-spin', () {
+      // 4×6 board with a T-slot: side blocks at (0,5)/(2,5) and an overhang at
+      // (0,3); a vertical T rotated CW drops its nub into the hole at (1,5).
+      final List<TetrominoType?> cells =
+          List<TetrominoType?>.filled(4 * 6, null);
+      int idx(int x, int y) => (y * 4) + x;
+      cells[idx(0, 3)] = TetrominoType.l;
+      cells[idx(0, 5)] = TetrominoType.l;
+      cells[idx(2, 5)] = TetrominoType.l;
+
+      final TetrisEngine engine = TetrisEngine(
+        width: 4,
+        height: 6,
+        lockDelay: const Duration(milliseconds: 50),
+        lineClearDelay: Duration.zero,
+      )..restore(<String, Object?>{
+          'board': TetrisBoard(width: 4, height: 6, cells: cells).toJson(),
+          'active': const FallingPiece(
+            type: TetrominoType.t,
+            rotationIndex: 1,
+            originX: 0,
+            originY: 3,
+          ).toJson(),
+        });
+      engine.drainEvents();
+
+      engine.applyInput(TetrisInput.rotateCw); // rotation is the last action
+      engine.tick(const Duration(milliseconds: 60)); // lock-delay expires
+
+      expect(
+        engine.drainEvents().map((TetrisEvent e) => e.type),
+        contains(TetrisEventType.tSpin),
+      );
+    });
+
+    test('combo increments and emits on a second consecutive clear', () {
+      // Restore mid-combo (_combo already 0); the next clear takes it to 1 and
+      // must emit a combo event.
+      final List<TetrominoType?> cells =
+          List<TetrominoType?>.filled(4 * 8, null);
+      int idx(int x, int y) => (y * 4) + x;
+      cells[idx(1, 7)] = TetrominoType.l;
+      cells[idx(2, 7)] = TetrominoType.l;
+      cells[idx(3, 7)] = TetrominoType.l;
+
+      final TetrisEngine engine = TetrisEngine(width: 4, height: 8)
+        ..restore(<String, Object?>{
+          'board': TetrisBoard(width: 4, height: 8, cells: cells).toJson(),
+          'active': const FallingPiece(
+            type: TetrominoType.i,
+            rotationIndex: 1,
+            originX: -2,
+            originY: 0,
+          ).toJson(),
+          'combo': 0,
+        });
+      engine.drainEvents();
+
+      engine.applyInput(TetrisInput.hardDrop);
+
+      expect(
+        engine.drainEvents().map((TetrisEvent e) => e.type),
+        contains(TetrisEventType.combo),
+      );
+    });
+
+    test('restore re-spawns when the snapshot active piece collides', () {
+      // Bottom half full, top empty; the snapshot resumes into an O that
+      // overlaps the stack. Restore must drop it and spawn a fresh piece rather
+      // than resuming inside a collision.
+      final List<TetrominoType?> cells =
+          List<TetrominoType?>.filled(4 * 8, null);
+      for (int y = 4; y < 8; y++) {
+        for (int x = 0; x < 4; x++) {
+          cells[(y * 4) + x] = TetrominoType.l;
+        }
+      }
+      final TetrisEngine engine = TetrisEngine(width: 4, height: 8)
+        ..restore(<String, Object?>{
+          'board': TetrisBoard(width: 4, height: 8, cells: cells).toJson(),
+          'active': const FallingPiece(
+            type: TetrominoType.o,
+            rotationIndex: 0,
+            originX: 0,
+            originY: 6, // overlaps the filled bottom rows
+          ).toJson(),
+        });
+
+      expect(engine.isGameOver, isFalse);
+      expect(engine.active, isNotNull);
+      // Spawned cleanly at the top, not resumed inside the stack.
+      expect(engine.active!.originY, lessThan(4));
+    });
   });
 }

--- a/docs/DOCS_CHANGELOG.md
+++ b/docs/DOCS_CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Append one dated line per status-changing documentation merge. The canonical status of the product is [roadmap/05_IMPLEMENTATION_STATUS.md](roadmap/05_IMPLEMENTATION_STATUS.md); this log records *when and why* it (and other load-bearing docs) changed. Supersedes the archived `archive/root/DOCS_CHANGELOG_2026-02-26.md`.
 
+## 2026-06-21 (Review follow-ups — batch 2)
+- Closed the remaining engine/analytics follow-ups from the PR #42 review: **#4** revive-once flag now persisted in the snapshot; **#6** perfect-clear awarded on the zero-delay path; **#7** lock-flash uses engine-captured `lastLockedCells` (correct on hard drop); **#8** gravity no longer consumes the lock-reset cap; **#9** `restore()` re-spawns when the active piece collides; **#12** Classic `move_rejected` reason defaults to `invalid_move`; **#13** `game_start` carries a `resumed` flag (schema updated). Plus perf (cached board-background `Picture`) and `reviveClearTop` combo/b2b reset. `flutter analyze` clean; **167 tests** (+4). Billing edges **#10/#11 deferred** (need Play sandbox + deployed function). Details: [audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md](audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md).
+
 ## 2026-06-21 (Review follow-ups — batch 1)
 - Closed the 4 priority follow-ups from the PR #42 review: (1) billing token binding is now atomic (check inside `runTransaction` in `verifyPurchase`); (2) `game_end` de-duplicated per round in both Tetris and Classic (`_gameEndEmitted` guard); (3) mid-clear snapshot no longer loses the lock/score (`TetrisEngine.flushPendingClear` invoked from `saveActiveGame`); (4) Tetris teardown hardened (controller `_disposed` guard + `onVisualEvent` cleared + Flame loop paused on dispose). `flutter analyze` clean; 163 tests. Details: [audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md](audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md).
 

--- a/docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md
+++ b/docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md
@@ -11,7 +11,22 @@ Done on branch `fix/review-followups-p1` (analyze clean, 163 tests):
 - ✅ **#3 Snapshot lost during the clear window** — `saveActiveGame()` now calls `engine.flushPendingClear()` (collapse + commit) before snapshotting; added `TetrisEngine.flushPendingClear` + test.
 - ✅ **#5 Tetris teardown** — `TetrisController` is now disposed-guarded (`_disposed` short-circuits tick/input/revive) and clears `onVisualEvent` on dispose; `TetrisScreen.dispose()` pauses the Flame loop before disposing.
 
-Remaining items (#4, #6–#13, perf/polish, test gaps) are still open below.
+## Resolved — batch 2 (2026-06-21)
+Done on branch `fix/review-followups-p2` (analyze clean, 167 tests):
+- ✅ **#4 Revive flag persisted** — `revive_used` is now written into the resume snapshot (`saveActiveGame`) and read back in `initialize()`, so backgrounding after a revive can't grant a second one.
+- ✅ **#6 Perfect clear on the zero-delay path** — extracted `_awardPerfectClearIfEmpty()`, called from both `_finishClear` and the `lineClearDelay <= 0` fast path in `_lockActivePiece`. (+test)
+- ✅ **#7 Lock-flash position on hard drop** — the engine captures the visible locked cells at lock time (`lastLockedCells`); the view flashes those instead of the last *rendered* active cells (which are stale after a hard drop).
+- ✅ **#8 Gravity no longer consumes the lock-reset cap** — `_tryMove(..., isGravity: true)` skips `_onPieceShifted()`; only player moves/rotations burn a reset. (Clearing `_lastActionWasRotation` on a *successful* gravity step is kept intentionally — guideline "last action = rotation"; a grounded gravity tick fails the collision check before touching the flag, so valid T-spins still register. +T-spin test.)
+- ✅ **#9 `restore()` validates the active piece** — if the restored piece collides with the board, it is dropped and re-spawned (block-out surfaces normally). (+test)
+- ✅ **#12 `move_rejected` null reason** — Classic now passes `placeResult.failureReason ?? 'invalid_move'` so the event is never quarantined for a null `reason`.
+- ✅ **#13 Resumed `game_start`** — a `resumed` flag is emitted with `game_start` (true when restored from a snapshot) and added to the analytics schema, so resumes can be distinguished from fresh sessions.
+- ✅ **Perf** — Tetris board chrome (gradient + grid + border) is recorded once into a cached `ui.Picture` and re-recorded only when geometry changes, instead of rebuilding shaders + drawing every grid line each frame.
+- ✅ **`reviveClearTop` resets `_combo`/`_backToBack`** — a revive breaks the run chain so no stale b2b/combo multiplier carries across the gap.
+- Tests: +combo accounting, +perfect-clear zero-delay, +T-spin detection, +restore-collision re-spawn.
+
+**Deferred (need a Play sandbox + the function deployed):** #10 (`restorePurchases` fixed-window) and #11 (receipt retry/backoff). These touch live billing flows that can't be exercised until `verifyPurchase` is deployed and a Play sandbox account is wired; tracked for the billing-enablement pass.
+
+Remaining items (perf/polish nits, the music-on-pop-back cosmetic, broader test/widget gaps) are still open below.
 
 ## Confirmed — prioritize first
 1. **Billing token binding is not atomic (TOCTOU).** `verifyPurchase` reads the token doc with a plain `get()` outside the transaction and never re-reads it inside `runTransaction`, so two concurrent calls with the same `purchaseToken` under different UIDs can both grant. Move the existence/uid check inside `runTransaction` (`tx.get` before `tx.set`). `infra/cloud_functions/functions/index.js:60-116`. (Function not yet deployed — fix before deploy.)


### PR DESCRIPTION
## Summary
Closes the remaining engine/analytics follow-ups from the PR #42 pre-merge review (batch 1 shipped in #43). All items are post-merge nits — none broke a core flow.

| # | Item | Fix |
|---|------|-----|
| #4 | Revive flag not persisted | `revive_used` now stored in the resume snapshot and read back on `initialize()` |
| #6 | Perfect-clear bypassed on zero-delay path | extracted `_awardPerfectClearIfEmpty()`, called from both clear paths |
| #7 | Lock-flash at stale position on hard drop | engine captures visible `lastLockedCells` at lock time; view flashes those |
| #8 | Gravity consumed the lock-reset cap | `_tryMove(..., isGravity: true)` skips `_onPieceShifted()` |
| #9 | `restore()` could resume into a collision | re-spawns the active piece if it collides after restore |
| #12 | `move_rejected` quarantined on null reason | Classic passes `failureReason ?? 'invalid_move'` |
| #13 | Resume emitted a fresh `game_start` | `game_start` carries a `resumed` flag (schema updated) |

Also: cached the static Tetris board background in a `ui.Picture` (perf — no per-frame shader/grid rebuild), and `reviveClearTop` now resets `_combo`/`_backToBack`.

**Deferred:** billing edges #10 (`restorePurchases` fixed-window) and #11 (receipt retry/backoff) — they need a Play sandbox + the deployed `verifyPurchase` function; tracked for the billing-enablement pass.

## Tests
`flutter analyze` clean; **167 tests pass** (+4: combo accounting, perfect-clear zero-delay, T-spin detection, restore-collision re-spawn).

Details: `docs/audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md` (batch-2 section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)