### PR TITLE
feat: Match-3 ("Три в ряд") — third game on the shared meta-layer

### DIFF
--- a/apps/mobile/lib/core/di/di_container.dart
+++ b/apps/mobile/lib/core/di/di_container.dart
@@ -51,6 +51,7 @@ import '../../features/monetization/debug_ad_service.dart';
 import '../../features/monetization/iap_store_service.dart';
 import '../../features/monetization/local_catalog_iap_store_service.dart';
 import '../../features/store/application/store_controller.dart';
+import '../../features/match3/application/match3_session_store.dart';
 import '../../features/tetris/application/tetris_session_store.dart';
 import '../config/app_config.dart';
 import '../logging/app_logger.dart';
@@ -236,6 +237,10 @@ Future<void> configureDependencies() async {
 
   sl.registerLazySingleton<TetrisSessionStore>(
     () => TetrisSessionStore(logger: sl()),
+  );
+
+  sl.registerLazySingleton<Match3SessionStore>(
+    () => Match3SessionStore(logger: sl()),
   );
 
   sl.registerFactory<StoreController>(

--- a/apps/mobile/lib/data/analytics/analytics_schema_validator.dart
+++ b/apps/mobile/lib/data/analytics/analytics_schema_validator.dart
@@ -160,6 +160,7 @@ class AnalyticsSchemaValidator {
         'rack_size',
         'ux_variant',
         'difficulty_variant',
+        'resumed',
       },
     ),
     'move_made': AnalyticsEventSchema(
@@ -198,6 +199,7 @@ class AnalyticsSchemaValidator {
         'game_id',
         'round_id',
         'score_total',
+        'cascade',
       },
     ),
     'game_end': AnalyticsEventSchema(
@@ -211,6 +213,7 @@ class AnalyticsSchemaValidator {
         'game_id',
         'level',
         'lines',
+        'moves_used',
         'ux_variant',
         'difficulty_variant',
       },

--- a/apps/mobile/lib/domain/match3/cascade_resolver.dart
+++ b/apps/mobile/lib/domain/match3/cascade_resolver.dart
@@ -1,0 +1,121 @@
+import 'match3_scoring.dart';
+import 'match_detector.dart';
+import 'tile.dart';
+import 'tile_grid.dart';
+import 'tile_spawner.dart';
+
+/// One step of a cascade: the cells cleared, plus the metadata the presentation
+/// and scoring layers need.
+class CascadeStep {
+  const CascadeStep({
+    required this.cleared,
+    required this.cascadeLevel,
+    required this.longestRun,
+    required this.gained,
+  });
+
+  /// Cells removed in this step (pre-gravity positions).
+  final Set<GridPos> cleared;
+
+  /// 1 for the swap's own match, 2 for the first chained match, etc.
+  final int cascadeLevel;
+
+  /// Length of the longest single run cleared this step.
+  final int longestRun;
+
+  /// Points awarded for this step.
+  final int gained;
+}
+
+/// The full result of resolving a board to a stable (match-free) state.
+class CascadeOutcome {
+  const CascadeOutcome({required this.grid, required this.steps});
+
+  /// The settled board (guaranteed match-free; no nulls if the input was full).
+  final TileGrid grid;
+
+  /// The cascade steps in order; empty if the input had no matches.
+  final List<CascadeStep> steps;
+
+  bool get hadMatch => steps.isNotEmpty;
+  int get cascadeCount => steps.length;
+  int get totalCleared =>
+      steps.fold(0, (int sum, CascadeStep s) => sum + s.cleared.length);
+  int get totalScore => steps.fold(0, (int sum, CascadeStep s) => sum + s.gained);
+}
+
+/// Drives the clear → gravity → refill → re-detect loop until the board is
+/// stable. This is the deterministic heart of Match-3; it is validated by
+/// table-driven unit tests before any animation work.
+class CascadeResolver {
+  CascadeResolver({
+    MatchDetector detector = const MatchDetector(),
+    required TileSpawner spawner,
+  })  : _detector = detector,
+        _spawner = spawner;
+
+  final MatchDetector _detector;
+  final TileSpawner _spawner;
+
+  /// Resolves [grid] fully, returning the settled board and a per-step record.
+  CascadeOutcome resolve(TileGrid grid) {
+    final List<CascadeStep> steps = <CascadeStep>[];
+    TileGrid current = grid;
+    int level = 0;
+
+    while (true) {
+      final List<TileMatch> matches = _detector.findMatches(current);
+      if (matches.isEmpty) {
+        break;
+      }
+      level += 1;
+
+      final Set<GridPos> cleared = <GridPos>{};
+      int longestRun = 0;
+      for (final TileMatch m in matches) {
+        cleared.addAll(m.cells);
+        if (m.length > longestRun) {
+          longestRun = m.length;
+        }
+      }
+
+      final int gained = Match3Scoring.clearScore(
+        clearedCount: cleared.length,
+        longestRun: longestRun,
+        cascadeLevel: level,
+      );
+
+      steps.add(CascadeStep(
+        cleared: cleared,
+        cascadeLevel: level,
+        longestRun: longestRun,
+        gained: gained,
+      ));
+
+      current = current.clearedAt(cleared);
+      current = applyGravity(current);
+      current = _spawner.refill(current);
+    }
+
+    return CascadeOutcome(grid: current, steps: steps);
+  }
+
+  /// Collapses each column so non-null tiles fall to the bottom, leaving the
+  /// holes at the top (to be refilled). Stable within a column (preserves order).
+  TileGrid applyGravity(TileGrid grid) {
+    final List<TileColor?> next =
+        List<TileColor?>.filled(grid.width * grid.height, null);
+    int index(int x, int y) => (y * grid.width) + x;
+    for (int x = 0; x < grid.width; x++) {
+      int writeY = grid.height - 1;
+      for (int y = grid.height - 1; y >= 0; y--) {
+        final TileColor? c = grid.at(x, y);
+        if (c != null) {
+          next[index(x, writeY)] = c;
+          writeY -= 1;
+        }
+      }
+    }
+    return TileGrid(width: grid.width, height: grid.height, cells: next);
+  }
+}

--- a/apps/mobile/lib/domain/match3/cascade_resolver.dart
+++ b/apps/mobile/lib/domain/match3/cascade_resolver.dart
@@ -9,6 +9,7 @@ import 'tile_spawner.dart';
 class CascadeStep {
   const CascadeStep({
     required this.cleared,
+    required this.clearedColors,
     required this.cascadeLevel,
     required this.longestRun,
     required this.gained,
@@ -16,6 +17,10 @@ class CascadeStep {
 
   /// Cells removed in this step (pre-gravity positions).
   final Set<GridPos> cleared;
+
+  /// Color of each cleared cell, captured before removal (so the presentation
+  /// layer can spawn matching-colored particles after the board has settled).
+  final Map<GridPos, TileColor> clearedColors;
 
   /// 1 for the swap's own match, 2 for the first chained match, etc.
   final int cascadeLevel;
@@ -78,6 +83,10 @@ class CascadeResolver {
           longestRun = m.length;
         }
       }
+      final Map<GridPos, TileColor> clearedColors = <GridPos, TileColor>{
+        for (final GridPos p in cleared)
+          if (current.atPos(p) != null) p: current.atPos(p)!,
+      };
 
       final int gained = Match3Scoring.clearScore(
         clearedCount: cleared.length,
@@ -87,6 +96,7 @@ class CascadeResolver {
 
       steps.add(CascadeStep(
         cleared: cleared,
+        clearedColors: clearedColors,
         cascadeLevel: level,
         longestRun: longestRun,
         gained: gained,

--- a/apps/mobile/lib/domain/match3/match3_engine.dart
+++ b/apps/mobile/lib/domain/match3/match3_engine.dart
@@ -73,6 +73,11 @@ class Match3Engine {
   bool _started = false;
   bool _gameOver = false;
 
+  /// Cells cleared by the most recent swap (union across its cascade steps),
+  /// with the color each held at clear time — for the view's particle bursts.
+  final List<({GridPos pos, TileColor color})> _lastCleared =
+      <({GridPos pos, TileColor color})>[];
+
   final List<Match3Event> _events = <Match3Event>[];
 
   // ── Public state ──
@@ -85,6 +90,8 @@ class Match3Engine {
   bool get isGameOver => _gameOver;
   bool get hasActiveGame => _started && !_gameOver;
   int get colorCount => _spawner.colorCount;
+  List<({GridPos pos, TileColor color})> get lastCleared =>
+      List<({GridPos pos, TileColor color})>.unmodifiable(_lastCleared);
 
   /// Begins the run: fills a starting board with no pre-existing match and at
   /// least one legal move. Idempotent.
@@ -119,6 +126,14 @@ class Match3Engine {
     final CascadeOutcome outcome = _resolver.resolve(_grid);
     _grid = outcome.grid;
     _score += outcome.totalScore;
+    _lastCleared
+      ..clear()
+      ..addAll(<({GridPos pos, TileColor color})>[
+        for (final CascadeStep step in outcome.steps)
+          for (final MapEntry<GridPos, TileColor> e
+              in step.clearedColors.entries)
+            (pos: e.key, color: e.value),
+      ]);
     for (final CascadeStep step in outcome.steps) {
       _events.add(Match3Event(
         Match3EventType.match,

--- a/apps/mobile/lib/domain/match3/match3_engine.dart
+++ b/apps/mobile/lib/domain/match3/match3_engine.dart
@@ -1,0 +1,220 @@
+import 'cascade_resolver.dart';
+import 'match_detector.dart';
+import 'swap_validator.dart';
+import 'tile.dart';
+import 'tile_grid.dart';
+import 'tile_spawner.dart';
+
+enum Match3EventType {
+  /// A legal swap was accepted (before the cascade resolves).
+  swap,
+
+  /// An attempted swap created no match and was reverted.
+  invalidSwap,
+
+  /// One clear step resolved. [value] = tiles cleared, [detail] = cascade level
+  /// (1 for the swap's own match, 2+ for chained matches).
+  match,
+
+  /// The board had no legal move and was reshuffled.
+  shuffle,
+
+  /// The run ended (move limit reached).
+  gameOver,
+}
+
+/// A discrete model event for the presentation layer (SFX, haptics, juice,
+/// analytics). Mirrors `TetrisEvent`.
+class Match3Event {
+  const Match3Event(this.type, [this.value = 0, this.detail = 0]);
+
+  final Match3EventType type;
+  final int value;
+  final int detail;
+}
+
+/// Pure-domain Match-3 rules engine. Holds the mutable run state and advances it
+/// via [swap] (the only player input). No Flutter/Flame dependencies; rendering
+/// and gesture handling live in the presentation layer. Events accumulate and
+/// are drained by the caller via [drainEvents].
+///
+/// A run is move-limited by default: each accepted swap consumes one move, and
+/// the run ends when [moveLimit] is reached. Mid-run dead ends (no legal swap)
+/// are resolved by reshuffling, so the board is always playable until then.
+class Match3Engine {
+  Match3Engine({
+    int? seed,
+    this.width = 8,
+    this.height = 8,
+    int colorCount = 6,
+    this.moveLimit = 30,
+  })  : assert(width >= 3 && height >= 3, 'board must be at least 3x3'),
+        assert(moveLimit == null || moveLimit > 0, 'moveLimit must be > 0'),
+        _spawner = TileSpawner(seed: seed, colorCount: colorCount),
+        _grid = TileGrid(width: width, height: height) {
+    _resolver = CascadeResolver(detector: _detector, spawner: _spawner);
+  }
+
+  final int width;
+  final int height;
+
+  /// Max accepted swaps before the run ends; null = endless (never ends on its
+  /// own, dead ends still reshuffle).
+  final int? moveLimit;
+
+  final TileSpawner _spawner;
+  final SwapValidator _validator = const SwapValidator();
+  final MatchDetector _detector = const MatchDetector();
+  late final CascadeResolver _resolver;
+
+  TileGrid _grid;
+  int _score = 0;
+  int _movesUsed = 0;
+  bool _started = false;
+  bool _gameOver = false;
+
+  final List<Match3Event> _events = <Match3Event>[];
+
+  // ── Public state ──
+  TileGrid get grid => _grid;
+  int get score => _score;
+  int get movesUsed => _movesUsed;
+  int? get movesLeft =>
+      moveLimit == null ? null : (moveLimit! - _movesUsed).clamp(0, moveLimit!);
+  bool get isStarted => _started;
+  bool get isGameOver => _gameOver;
+  bool get hasActiveGame => _started && !_gameOver;
+  int get colorCount => _spawner.colorCount;
+
+  /// Begins the run: fills a starting board with no pre-existing match and at
+  /// least one legal move. Idempotent.
+  void start() {
+    if (_started) {
+      return;
+    }
+    _started = true;
+    _grid = _spawner.fillInitial(width, height);
+    _ensurePlayable();
+  }
+
+  /// Attempts to swap the tiles at [a] and [b]. Returns true if a legal move was
+  /// made (adjacent + creates a match); the cascade is resolved and a move is
+  /// consumed. Returns false for a non-adjacent pair (no-op) or an adjacent pair
+  /// that makes no match (reverted, emits [Match3EventType.invalidSwap]).
+  bool swap(GridPos a, GridPos b) {
+    if (!hasActiveGame) {
+      return false;
+    }
+    if (!_validator.isAdjacent(a, b)) {
+      return false;
+    }
+    if (!_validator.producesMatch(_grid, a, b)) {
+      _events.add(const Match3Event(Match3EventType.invalidSwap));
+      return false;
+    }
+
+    _grid = _grid.swapped(a, b);
+    _events.add(const Match3Event(Match3EventType.swap));
+
+    final CascadeOutcome outcome = _resolver.resolve(_grid);
+    _grid = outcome.grid;
+    _score += outcome.totalScore;
+    for (final CascadeStep step in outcome.steps) {
+      _events.add(Match3Event(
+        Match3EventType.match,
+        step.cleared.length,
+        step.cascadeLevel,
+      ));
+    }
+
+    _movesUsed += 1;
+    _ensurePlayable();
+
+    if (moveLimit != null && _movesUsed >= moveLimit!) {
+      _gameOver = true;
+      _events.add(const Match3Event(Match3EventType.gameOver));
+    }
+    return true;
+  }
+
+  /// True if any legal swap exists on the current board.
+  bool hasPossibleMove() => _findAnyMove() != null;
+
+  /// Returns a hint: one legal (a, b) swap, or null if the board is a dead end.
+  (GridPos, GridPos)? findHint() => _findAnyMove();
+
+  /// Drains accumulated events since the last call.
+  List<Match3Event> drainEvents() {
+    final List<Match3Event> drained = List<Match3Event>.of(_events);
+    _events.clear();
+    return drained;
+  }
+
+  // ── Internals ──
+
+  /// Ensures the board has at least one legal move, reshuffling if not. A reshuffle
+  /// re-rolls the whole board (no pre-existing match) and emits a shuffle event.
+  void _ensurePlayable() {
+    if (hasPossibleMove()) {
+      return;
+    }
+    // Bounded re-roll; with >= 3 colors a playable board is found almost always
+    // on the first try, but cap attempts so this can never spin forever.
+    for (int attempt = 0; attempt < 64; attempt++) {
+      _grid = _spawner.fillInitial(width, height);
+      if (hasPossibleMove()) {
+        break;
+      }
+    }
+    _events.add(const Match3Event(Match3EventType.shuffle));
+  }
+
+  (GridPos, GridPos)? _findAnyMove() {
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final GridPos here = GridPos(x, y);
+        if (x + 1 < width) {
+          final GridPos right = GridPos(x + 1, y);
+          if (_validator.producesMatch(_grid, here, right)) {
+            return (here, right);
+          }
+        }
+        if (y + 1 < height) {
+          final GridPos down = GridPos(x, y + 1);
+          if (_validator.producesMatch(_grid, here, down)) {
+            return (here, down);
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  Map<String, Object?> toSnapshot() => <String, Object?>{
+        'grid': _grid.toJson(),
+        'score': _score,
+        'moves_used': _movesUsed,
+        'move_limit': moveLimit,
+      };
+
+  /// Restores a run from [toSnapshot]. Marks the engine started; ensures the
+  /// restored board is playable (reshuffles a dead-end snapshot).
+  void restore(Map<String, Object?> json) {
+    _started = true;
+    _gameOver = false;
+    _grid = TileGrid.fromJson(
+      (json['grid'] as Map?)?.cast<String, Object?>() ?? <String, Object?>{},
+    );
+    _score = json['score'] as int? ?? 0;
+    _movesUsed = json['moves_used'] as int? ?? 0;
+    // A corrupt/partial snapshot grid (holes, or no legal move) is made playable
+    // rather than resuming into an unplayable state.
+    if (!_grid.isFull) {
+      _grid = _spawner.refill(_grid);
+    }
+    _ensurePlayable();
+    if (moveLimit != null && _movesUsed >= moveLimit!) {
+      _gameOver = true;
+    }
+  }
+}

--- a/apps/mobile/lib/domain/match3/match3_scoring.dart
+++ b/apps/mobile/lib/domain/match3/match3_scoring.dart
@@ -1,0 +1,42 @@
+/// Match-3 scoring rules. Pure and static, mirroring `TetrisScoring`.
+///
+/// Score for one clear step scales with the number of tiles removed, the length
+/// of the longest run (4/5-in-a-row bonuses), and the cascade depth (a chain
+/// reaction is worth progressively more).
+class Match3Scoring {
+  const Match3Scoring._();
+
+  /// Base points awarded per cleared tile.
+  static const int basePerTile = 30;
+
+  /// Points for one clear step.
+  ///
+  /// - [clearedCount]: number of tiles removed this step.
+  /// - [longestRun]: length of the longest single run in this step (>= 3).
+  /// - [cascadeLevel]: 1 for the swap's own match, 2 for the first chain, etc.;
+  ///   acts as a multiplier so deep cascades pay off.
+  static int clearScore({
+    required int clearedCount,
+    required int longestRun,
+    required int cascadeLevel,
+  }) {
+    if (clearedCount <= 0) {
+      return 0;
+    }
+    final int level = cascadeLevel < 1 ? 1 : cascadeLevel;
+    final int base = clearedCount * basePerTile;
+    return (base + _runBonus(longestRun)) * level;
+  }
+
+  /// Flat bonus for big single runs (a 4-match and 5-match are special in most
+  /// match-3 games even before special-tile spawns are introduced).
+  static int _runBonus(int longestRun) {
+    if (longestRun >= 5) {
+      return 150;
+    }
+    if (longestRun == 4) {
+      return 60;
+    }
+    return 0;
+  }
+}

--- a/apps/mobile/lib/domain/match3/match_detector.dart
+++ b/apps/mobile/lib/domain/match3/match_detector.dart
@@ -1,0 +1,121 @@
+import 'tile.dart';
+import 'tile_grid.dart';
+
+/// A single straight run of 3+ same-color tiles, horizontal or vertical.
+/// Overlapping runs (the arms of an L/T shape) are reported as separate matches;
+/// use [MatchDetector.matchedCells] for the de-duplicated set to clear.
+class TileMatch {
+  const TileMatch({
+    required this.cells,
+    required this.color,
+    required this.horizontal,
+  });
+
+  final List<GridPos> cells;
+  final TileColor color;
+  final bool horizontal;
+
+  int get length => cells.length;
+}
+
+/// Finds maximal straight runs of 3+ identical tiles in a [TileGrid]. Pure and
+/// allocation-light; the cascade resolver calls this repeatedly per move.
+class MatchDetector {
+  const MatchDetector();
+
+  /// All horizontal and vertical runs of length >= 3. Nulls never match.
+  List<TileMatch> findMatches(TileGrid grid) {
+    final List<TileMatch> matches = <TileMatch>[];
+
+    // Horizontal runs.
+    for (int y = 0; y < grid.height; y++) {
+      int runStart = 0;
+      for (int x = 1; x <= grid.width; x++) {
+        final TileColor? prev = grid.at(x - 1, y);
+        final TileColor? cur = x < grid.width ? grid.at(x, y) : null;
+        final bool sameRun = cur != null && cur == prev;
+        if (!sameRun) {
+          final int runLen = x - runStart;
+          if (prev != null && runLen >= 3) {
+            matches.add(TileMatch(
+              color: prev,
+              horizontal: true,
+              cells: <GridPos>[
+                for (int rx = runStart; rx < x; rx++) GridPos(rx, y),
+              ],
+            ));
+          }
+          runStart = x;
+        }
+      }
+    }
+
+    // Vertical runs.
+    for (int x = 0; x < grid.width; x++) {
+      int runStart = 0;
+      for (int y = 1; y <= grid.height; y++) {
+        final TileColor? prev = grid.at(x, y - 1);
+        final TileColor? cur = y < grid.height ? grid.at(x, y) : null;
+        final bool sameRun = cur != null && cur == prev;
+        if (!sameRun) {
+          final int runLen = y - runStart;
+          if (prev != null && runLen >= 3) {
+            matches.add(TileMatch(
+              color: prev,
+              horizontal: false,
+              cells: <GridPos>[
+                for (int ry = runStart; ry < y; ry++) GridPos(x, ry),
+              ],
+            ));
+          }
+          runStart = y;
+        }
+      }
+    }
+
+    return matches;
+  }
+
+  /// The de-duplicated set of all matched cells (union of every run), which is
+  /// what actually gets cleared.
+  Set<GridPos> matchedCells(TileGrid grid) {
+    final Set<GridPos> cells = <GridPos>{};
+    for (final TileMatch m in findMatches(grid)) {
+      cells.addAll(m.cells);
+    }
+    return cells;
+  }
+
+  /// Cheap existence check (used by swap validation and no-moves detection).
+  bool hasMatch(TileGrid grid) {
+    // Horizontal.
+    for (int y = 0; y < grid.height; y++) {
+      int run = 1;
+      for (int x = 1; x < grid.width; x++) {
+        final TileColor? cur = grid.at(x, y);
+        if (cur != null && cur == grid.at(x - 1, y)) {
+          if (++run >= 3) {
+            return true;
+          }
+        } else {
+          run = 1;
+        }
+      }
+    }
+    // Vertical.
+    for (int x = 0; x < grid.width; x++) {
+      int run = 1;
+      for (int y = 1; y < grid.height; y++) {
+        final TileColor? cur = grid.at(x, y);
+        if (cur != null && cur == grid.at(x, y - 1)) {
+          if (++run >= 3) {
+            return true;
+          }
+        } else {
+          run = 1;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/apps/mobile/lib/domain/match3/swap_validator.dart
+++ b/apps/mobile/lib/domain/match3/swap_validator.dart
@@ -1,0 +1,33 @@
+import 'match_detector.dart';
+import 'tile.dart';
+import 'tile_grid.dart';
+
+/// Validates a player swap: two tiles may only be exchanged if they are
+/// orthogonally adjacent and the exchange creates at least one match. This is
+/// the "revert on no-match" rule of classic Match-3.
+class SwapValidator {
+  const SwapValidator({MatchDetector detector = const MatchDetector()})
+      : _detector = detector;
+
+  final MatchDetector _detector;
+
+  /// True if [a] and [b] are orthogonal neighbors exactly one cell apart.
+  bool isAdjacent(GridPos a, GridPos b) {
+    final int dx = (a.x - b.x).abs();
+    final int dy = (a.y - b.y).abs();
+    return (dx + dy) == 1;
+  }
+
+  /// True if exchanging [a] and [b] yields a board with at least one match.
+  /// Does not require adjacency — combine with [isAdjacent] for a legal move.
+  bool producesMatch(TileGrid grid, GridPos a, GridPos b) {
+    if (grid.atPos(a) == null || grid.atPos(b) == null) {
+      return false;
+    }
+    return _detector.hasMatch(grid.swapped(a, b));
+  }
+
+  /// A fully legal player move: adjacent AND creates a match.
+  bool isLegalSwap(TileGrid grid, GridPos a, GridPos b) =>
+      isAdjacent(a, b) && producesMatch(grid, a, b);
+}

--- a/apps/mobile/lib/domain/match3/tile.dart
+++ b/apps/mobile/lib/domain/match3/tile.dart
@@ -1,0 +1,47 @@
+/// Pure-domain Match-3 primitives. No Flutter/Flame dependencies — mirrors the
+/// SDK-independent discipline of `lib/domain/gameplay` and `lib/domain/tetris`.
+///
+/// Geometry convention: board coordinates have **y increasing downward** (row 0
+/// at the top, gravity pulls tiles toward higher y), x increasing to the right,
+/// origin at the top-left — matching `TetrisBoard` and `BoardState`.
+library;
+
+/// A cell position on the Match-3 grid.
+class GridPos {
+  const GridPos(this.x, this.y);
+
+  final int x;
+  final int y;
+
+  @override
+  bool operator ==(Object other) =>
+      other is GridPos && other.x == x && other.y == y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+
+  @override
+  String toString() => '($x,$y)';
+}
+
+/// Gem colors. The spawner uses the first `colorCount` of these, so the
+/// declaration order is the difficulty order (fewer colors = easier).
+///
+/// Specials (line/bomb gems) are intentionally out of scope for this core: the
+/// match/cascade state machine is validated on plain tiles first, since the
+/// special×special detonation matrix is the classic source of match-3 clone
+/// bugs (see the multi-game plan, risk #2).
+enum TileColor { ruby, amber, citrine, emerald, sapphire, amethyst }
+
+/// Resolves a persisted color name back to its enum value, or null.
+TileColor? tileColorFromName(Object? name) {
+  if (name is! String) {
+    return null;
+  }
+  for (final TileColor c in TileColor.values) {
+    if (c.name == name) {
+      return c;
+    }
+  }
+  return null;
+}

--- a/apps/mobile/lib/domain/match3/tile_grid.dart
+++ b/apps/mobile/lib/domain/match3/tile_grid.dart
@@ -1,0 +1,94 @@
+import 'tile.dart';
+
+/// A rectangular Match-3 board. Each cell holds the [TileColor] of its gem, or
+/// `null` for a transient hole (during the clear → gravity → refill window).
+/// A settled board has no nulls. Coordinates are y-down, x-right, origin at the
+/// top-left (gravity pulls toward higher y).
+///
+/// Instances are treated as immutable: mutating operations ([swapped],
+/// [withCell], [clearedAt]) return a new grid, mirroring [TetrisBoard].
+class TileGrid {
+  TileGrid({
+    required this.width,
+    required this.height,
+    List<TileColor?>? cells,
+  }) : _cells = cells ?? List<TileColor?>.filled(width * height, null) {
+    assert(_cells.length == width * height, 'cells length must be width*height');
+  }
+
+  final int width;
+  final int height;
+  final List<TileColor?> _cells;
+
+  int _index(int x, int y) => (y * width) + x;
+
+  bool inBounds(int x, int y) => x >= 0 && x < width && y >= 0 && y < height;
+
+  TileColor? at(int x, int y) => inBounds(x, y) ? _cells[_index(x, y)] : null;
+
+  TileColor? atPos(GridPos p) => at(p.x, p.y);
+
+  /// True when every cell is filled (the settled, playable state).
+  bool get isFull {
+    for (final TileColor? c in _cells) {
+      if (c == null) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Returns a copy with the tiles at [a] and [b] exchanged. Out-of-bounds
+  /// positions are ignored (the caller validates adjacency first).
+  TileGrid swapped(GridPos a, GridPos b) {
+    if (!inBounds(a.x, a.y) || !inBounds(b.x, b.y)) {
+      return this;
+    }
+    final List<TileColor?> next = List<TileColor?>.of(_cells);
+    final int ia = _index(a.x, a.y);
+    final int ib = _index(b.x, b.y);
+    final TileColor? tmp = next[ia];
+    next[ia] = next[ib];
+    next[ib] = tmp;
+    return TileGrid(width: width, height: height, cells: next);
+  }
+
+  /// Returns a copy with [color] (or null) written at ([x],[y]).
+  TileGrid withCell(int x, int y, TileColor? color) {
+    if (!inBounds(x, y)) {
+      return this;
+    }
+    final List<TileColor?> next = List<TileColor?>.of(_cells);
+    next[_index(x, y)] = color;
+    return TileGrid(width: width, height: height, cells: next);
+  }
+
+  /// Returns a copy with every position in [cells] set to null (cleared).
+  TileGrid clearedAt(Iterable<GridPos> cells) {
+    final List<TileColor?> next = List<TileColor?>.of(_cells);
+    for (final GridPos p in cells) {
+      if (inBounds(p.x, p.y)) {
+        next[_index(p.x, p.y)] = null;
+      }
+    }
+    return TileGrid(width: width, height: height, cells: next);
+  }
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'width': width,
+        'height': height,
+        'cells':
+            _cells.map((TileColor? c) => c?.name).toList(growable: false),
+      };
+
+  factory TileGrid.fromJson(Map<String, Object?> json) {
+    final int width = (json['width'] as int?) ?? 8;
+    final int height = (json['height'] as int?) ?? 8;
+    final List<dynamic> raw = (json['cells'] as List<dynamic>?) ?? <dynamic>[];
+    final List<TileColor?> cells = List<TileColor?>.generate(
+      width * height,
+      (int i) => i < raw.length ? tileColorFromName(raw[i]) : null,
+    );
+    return TileGrid(width: width, height: height, cells: cells);
+  }
+}

--- a/apps/mobile/lib/domain/match3/tile_spawner.dart
+++ b/apps/mobile/lib/domain/match3/tile_spawner.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+
+import 'tile.dart';
+import 'tile_grid.dart';
+
+/// Produces tiles for the initial board and for refilling after a cascade.
+/// Seeded for deterministic boards (daily challenge / replay) and unit tests.
+class TileSpawner {
+  TileSpawner({int? seed, int colorCount = 6})
+      : assert(colorCount >= 3 && colorCount <= TileColor.values.length,
+            'colorCount must be in 3..${TileColor.values.length}'),
+        _random = Random(seed),
+        _colors = TileColor.values.sublist(0, colorCount);
+
+  final Random _random;
+  final List<TileColor> _colors;
+
+  int get colorCount => _colors.length;
+
+  /// A uniformly-random color from the active palette.
+  TileColor next() => _colors[_random.nextInt(_colors.length)];
+
+  /// Builds a starting board with **no pre-existing match**: each cell avoids a
+  /// color that would complete a run of three with its already-placed left or
+  /// top neighbors. (Solvability — that a legal move exists — is enforced by the
+  /// engine, which reshuffles if the fresh board is a dead end.)
+  TileGrid fillInitial(int width, int height) {
+    final List<TileColor?> cells = List<TileColor?>.filled(width * height, null);
+    int index(int x, int y) => (y * width) + x;
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final TileColor? left2 = x >= 2 ? cells[index(x - 1, y)] : null;
+        final TileColor? leftMatch =
+            (x >= 2 && cells[index(x - 1, y)] == cells[index(x - 2, y)])
+                ? left2
+                : null;
+        final TileColor? upMatch =
+            (y >= 2 && cells[index(x, y - 1)] == cells[index(x, y - 2)])
+                ? cells[index(x, y - 1)]
+                : null;
+        TileColor color = next();
+        // Reroll until it doesn't extend a pair into a triple. The palette has
+        // >= 3 colors, so a valid choice always exists.
+        while (color == leftMatch || color == upMatch) {
+          color = next();
+        }
+        cells[index(x, y)] = color;
+      }
+    }
+    return TileGrid(width: width, height: height, cells: cells);
+  }
+
+  /// Fills every null cell of [grid] (the holes left after gravity) with fresh
+  /// random tiles. New matches are allowed — they drive the cascade.
+  TileGrid refill(TileGrid grid) {
+    TileGrid result = grid;
+    for (int y = 0; y < grid.height; y++) {
+      for (int x = 0; x < grid.width; x++) {
+        if (result.at(x, y) == null) {
+          result = result.withCell(x, y, next());
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/apps/mobile/lib/features/match3/application/match3_controller.dart
+++ b/apps/mobile/lib/features/match3/application/match3_controller.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/device/haptics_controller.dart';
+import '../../../data/analytics/analytics_tracker.dart';
+import '../../../domain/match3/match3_engine.dart';
+import '../../../domain/match3/tile.dart';
+import '../../../domain/match3/tile_grid.dart';
+import '../../game_loop/audio/game_sfx_player.dart';
+import 'match3_session_store.dart';
+
+/// Owns the [Match3Engine] and bridges it to the UI. The Flame view forwards
+/// board taps/swipes to [trySwap]; engine events become SFX, haptics, and
+/// analytics; HUD-relevant changes notify listeners. Persists a resume snapshot
+/// and the best score via [Match3SessionStore]. Mirrors `TetrisController`, but
+/// Match-3 has no clock — there is no [tick]; the engine advances only on swaps.
+class Match3Controller extends ChangeNotifier {
+  Match3Controller({
+    int? seed,
+    required GameSfxPlayer sfx,
+    required HapticsController haptics,
+    AnalyticsTracker? analyticsTracker,
+    Match3SessionStore? store,
+    VoidCallback? onGameOver,
+  })  : _seed = seed,
+        _sfx = sfx,
+        _haptics = haptics,
+        _analytics = analyticsTracker,
+        _store = store,
+        _onGameOver = onGameOver,
+        _engine = Match3Engine(seed: seed);
+
+  final int? _seed;
+  final GameSfxPlayer _sfx;
+  final HapticsController _haptics;
+  final AnalyticsTracker? _analytics;
+  final Match3SessionStore? _store;
+  final VoidCallback? _onGameOver;
+
+  Match3Engine _engine;
+  bool _started = false;
+  bool _gameEndEmitted = false;
+  bool _disposed = false;
+  int _bestScore = 0;
+  String _roundId = 'match3_0';
+  DateTime? _startedAt;
+
+  /// Set by the Flame view to receive engine events for visual juice.
+  void Function(Match3Event event)? onVisualEvent;
+
+  Match3Engine get engine => _engine;
+  TileGrid get grid => _engine.grid;
+  int get score => _engine.score;
+  int get movesUsed => _engine.movesUsed;
+  int? get movesLeft => _engine.movesLeft;
+  int get colorCount => _engine.colorCount;
+  bool get isGameOver => _engine.isGameOver;
+  int get bestScore => _bestScore > _engine.score ? _bestScore : _engine.score;
+
+  /// Loads the best score + any resume snapshot, then resumes or starts.
+  Future<void> initialize() async {
+    if (_started) {
+      return;
+    }
+    _started = true;
+    _bestScore = await (_store?.loadBestScore() ?? Future<int>.value(0));
+    final Map<String, Object?>? snapshot = await _store?.loadSnapshot();
+    final bool resumed = snapshot != null;
+    if (snapshot != null) {
+      _engine.restore(snapshot);
+    } else {
+      _engine.start();
+    }
+    _beginRound(resumed: resumed);
+    _consumeEvents();
+    notifyListeners();
+  }
+
+  void restart() {
+    unawaited(_store?.clearSnapshot());
+    _engine = Match3Engine(seed: _seed);
+    _engine.start();
+    _beginRound();
+    _consumeEvents();
+    notifyListeners();
+  }
+
+  /// Attempts the player's swap. Returns true if it was a legal move.
+  bool trySwap(GridPos a, GridPos b) {
+    if (_disposed || _engine.isGameOver) {
+      return false;
+    }
+    final bool ok = _engine.swap(a, b);
+    _consumeEvents();
+    notifyListeners();
+    return ok;
+  }
+
+  /// Persists the in-progress game (call on app pause). No-op when idle.
+  void saveActiveGame() {
+    final Match3SessionStore? store = _store;
+    if (store == null || !_engine.hasActiveGame) {
+      return;
+    }
+    unawaited(store.saveSnapshot(_engine.toSnapshot()));
+  }
+
+  void _beginRound({bool resumed = false}) {
+    _gameEndEmitted = false;
+    _startedAt = DateTime.now();
+    _roundId = 'match3_${_startedAt!.microsecondsSinceEpoch}';
+    _track('game_start', <String, Object?>{
+      'round_id': _roundId,
+      'mode': 'match3',
+      'config_version': 'match3_v1',
+      'game_id': 'match3',
+      'resumed': resumed,
+    });
+  }
+
+  bool _consumeEvents() {
+    final List<Match3Event> events = _engine.drainEvents();
+    if (events.isEmpty) {
+      return false;
+    }
+    for (final Match3Event event in events) {
+      _handle(event);
+    }
+    return true;
+  }
+
+  void _handle(Match3Event event) {
+    switch (event.type) {
+      case Match3EventType.swap:
+        unawaited(_sfx.playHold());
+        unawaited(_haptics.selectionClick());
+        break;
+      case Match3EventType.invalidSwap:
+        unawaited(_sfx.playInvalidMove());
+        unawaited(_haptics.lightImpact());
+        break;
+      case Match3EventType.match:
+        // value = tiles cleared, detail = cascade level.
+        unawaited(_sfx.playLineClear(clearedLines: (event.value / 3).ceil()));
+        if (event.detail >= 2) {
+          unawaited(_sfx.playCombo(comboStreak: event.detail));
+          unawaited(_haptics.heavyImpact());
+        } else {
+          unawaited(_haptics.lightImpact());
+        }
+        _track('line_clear', <String, Object?>{
+          'count': event.value,
+          'game_id': 'match3',
+          'round_id': _roundId,
+          'score_total': _engine.score,
+          'cascade': event.detail,
+        });
+        break;
+      case Match3EventType.shuffle:
+        unawaited(_sfx.playPiecePlaced());
+        unawaited(_haptics.mediumImpact());
+        break;
+      case Match3EventType.gameOver:
+        unawaited(_sfx.playGameOver());
+        unawaited(_haptics.heavyImpact());
+        _onGameEnd();
+        break;
+    }
+    onVisualEvent?.call(event);
+  }
+
+  void _onGameEnd() {
+    final int finalScore = _engine.score;
+    if (finalScore > _bestScore) {
+      _bestScore = finalScore;
+    }
+    unawaited(_store?.saveBestScore(finalScore));
+    unawaited(_store?.clearSnapshot());
+    if (!_gameEndEmitted) {
+      _gameEndEmitted = true;
+      final int duration = _startedAt == null
+          ? 0
+          : DateTime.now().difference(_startedAt!).inSeconds;
+      _track('game_end', <String, Object?>{
+        'round_id': _roundId,
+        'end_reason': 'out_of_moves',
+        'score': finalScore,
+        'duration_sec': duration,
+        'moves_used': _engine.movesUsed,
+        'game_id': 'match3',
+      });
+    }
+    _onGameOver?.call();
+  }
+
+  void _track(String name, Map<String, Object?> params) {
+    final AnalyticsTracker? analytics = _analytics;
+    if (analytics == null) {
+      return;
+    }
+    unawaited(analytics.track(name, params: params));
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    onVisualEvent = null;
+    super.dispose();
+  }
+}

--- a/apps/mobile/lib/features/match3/application/match3_session_store.dart
+++ b/apps/mobile/lib/features/match3/application/match3_session_store.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/logging/app_logger.dart';
+
+/// Match-3-only persistence (SharedPreferences): the best score and a resume
+/// snapshot. Kept separate from Classic's `GameSessionRepository` and from
+/// `TetrisSessionStore` so the three modes don't perturb each other; folds into
+/// the multi-game snapshot envelope when the shared engine seam lands
+/// (see docs/architecture/04_MULTI_GAME_ENGINE_PLAN.md).
+class Match3SessionStore {
+  Match3SessionStore({required AppLogger logger}) : _logger = logger;
+
+  final AppLogger _logger;
+  static const String _bestScoreKey = 'match3_best_score';
+  static const String _snapshotKey = 'match3_active_snapshot';
+
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _prefsInstance() async {
+    final SharedPreferences? cached = _prefs;
+    if (cached != null) {
+      return cached;
+    }
+    final SharedPreferences created = await SharedPreferences.getInstance();
+    _prefs = created;
+    return created;
+  }
+
+  Future<int> loadBestScore() async {
+    try {
+      final SharedPreferences prefs = await _prefsInstance();
+      return prefs.getInt(_bestScoreKey) ?? 0;
+    } catch (error) {
+      _logger.warn('Match3 loadBestScore failed: $error');
+      return 0;
+    }
+  }
+
+  Future<void> saveBestScore(int score) async {
+    try {
+      final SharedPreferences prefs = await _prefsInstance();
+      final int current = prefs.getInt(_bestScoreKey) ?? 0;
+      if (score > current) {
+        await prefs.setInt(_bestScoreKey, score);
+      }
+    } catch (error) {
+      _logger.warn('Match3 saveBestScore failed: $error');
+    }
+  }
+
+  Future<Map<String, Object?>?> loadSnapshot() async {
+    try {
+      final SharedPreferences prefs = await _prefsInstance();
+      final String? raw = prefs.getString(_snapshotKey);
+      if (raw == null) {
+        return null;
+      }
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        return null;
+      }
+      return decoded.cast<String, Object?>();
+    } catch (error) {
+      _logger.warn('Match3 loadSnapshot failed: $error');
+      return null;
+    }
+  }
+
+  Future<void> saveSnapshot(Map<String, Object?> snapshot) async {
+    try {
+      final SharedPreferences prefs = await _prefsInstance();
+      await prefs.setString(_snapshotKey, jsonEncode(snapshot));
+    } catch (error) {
+      _logger.warn('Match3 saveSnapshot failed: $error');
+    }
+  }
+
+  Future<void> clearSnapshot() async {
+    try {
+      final SharedPreferences prefs = await _prefsInstance();
+      await prefs.remove(_snapshotKey);
+    } catch (error) {
+      _logger.warn('Match3 clearSnapshot failed: $error');
+    }
+  }
+}

--- a/apps/mobile/lib/features/match3/presentation/match3_game.dart
+++ b/apps/mobile/lib/features/match3/presentation/match3_game.dart
@@ -1,0 +1,414 @@
+import 'dart:math' as math;
+
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+import '../../../domain/match3/match3_engine.dart';
+import '../../../domain/match3/tile.dart';
+import '../../../domain/match3/tile_grid.dart';
+import '../../../ui/effects/burst_field.dart';
+import '../application/match3_controller.dart';
+
+/// Gem colors (neon palette consistent with the Lumina look).
+const Map<TileColor, Color> gemColors = <TileColor, Color>{
+  TileColor.ruby: Color(0xFFF0566E),
+  TileColor.amber: Color(0xFFF0A24E),
+  TileColor.citrine: Color(0xFFF2D24E),
+  TileColor.emerald: Color(0xFF5FE08A),
+  TileColor.sapphire: Color(0xFF4DA6F0),
+  TileColor.amethyst: Color(0xFFB672EC),
+};
+
+/// Flame view for Match-3. Renders the gem grid, the current selection, and the
+/// clear/cascade juice. Input arrives from the Flutter layer (see
+/// `Match3Screen`), which maps a tap/swipe to a cell and calls [onCellTapped] /
+/// [onSwipe]; the view tracks the selection and asks the controller to swap.
+class Match3FlameGame extends FlameGame {
+  Match3FlameGame({required this.controller});
+
+  final Match3Controller controller;
+
+  GridPos? _selected;
+
+  // Visual-juice state.
+  double _flash = 0;
+  double _shake = 0;
+  String? _pulseText;
+  double _pulseElapsed = 0;
+  String? _scorePopText;
+  double _scorePopElapsed = 0;
+  double _clock = 0;
+  int _lastScore = 0;
+  bool _burstThisSwap = false;
+  final BurstField _burst = BurstField();
+
+  // Last board geometry (screen space).
+  double _ox = 0;
+  double _oy = 0;
+  double _cell = 0;
+
+  int get _cols => controller.engine.width;
+  int get _rows => controller.engine.height;
+
+  @override
+  Color backgroundColor() => const Color(0x00000000);
+
+  @override
+  Future<void> onLoad() async {
+    controller.onVisualEvent = _onVisualEvent;
+    _lastScore = controller.score;
+    await super.onLoad();
+  }
+
+  /// Maps a local pixel offset (within the GameWidget) to a cell, or null.
+  GridPos? cellAt(Offset local) {
+    if (_cell <= 0) {
+      return null;
+    }
+    final int x = ((local.dx - _ox) / _cell).floor();
+    final int y = ((local.dy - _oy) / _cell).floor();
+    if (x < 0 || x >= _cols || y < 0 || y >= _rows) {
+      return null;
+    }
+    return GridPos(x, y);
+  }
+
+  /// Tap-to-select, tap-adjacent-to-swap. Tapping the selected cell deselects;
+  /// tapping a non-adjacent cell re-selects it.
+  void onCellTapped(GridPos pos) {
+    final GridPos? sel = _selected;
+    if (sel == null) {
+      _selected = pos;
+      return;
+    }
+    if (sel == pos) {
+      _selected = null;
+      return;
+    }
+    if (_isAdjacent(sel, pos)) {
+      _selected = null;
+      controller.trySwap(sel, pos);
+    } else {
+      _selected = pos;
+    }
+  }
+
+  /// Swipe a tile toward a neighbor: swap it with that neighbor.
+  void onSwipe(GridPos from, int dx, int dy) {
+    _selected = null;
+    controller.trySwap(from, GridPos(from.x + dx, from.y + dy));
+  }
+
+  bool _isAdjacent(GridPos a, GridPos b) =>
+      ((a.x - b.x).abs() + (a.y - b.y).abs()) == 1;
+
+  void _onVisualEvent(Match3Event event) {
+    switch (event.type) {
+      case Match3EventType.swap:
+        _burstThisSwap = false;
+        break;
+      case Match3EventType.match:
+        if (!_burstThisSwap) {
+          _spawnClearParticles();
+          _burstThisSwap = true;
+          _flash = math.max(_flash, (event.value / 9).clamp(0.3, 1).toDouble());
+        }
+        if (event.detail >= 2) {
+          _shake = math.max(_shake, 0.5);
+          _pulse('COMBO x${event.detail}');
+        } else if (event.value >= 5) {
+          _pulse('NICE!');
+        }
+        break;
+      case Match3EventType.invalidSwap:
+        _shake = math.max(_shake, 0.25);
+        break;
+      case Match3EventType.shuffle:
+        _pulse('SHUFFLE');
+        _flash = math.max(_flash, 0.4);
+        break;
+      case Match3EventType.gameOver:
+        _shake = math.max(_shake, 0.7);
+        break;
+    }
+  }
+
+  void _spawnClearParticles() {
+    if (_cell <= 0) {
+      return;
+    }
+    for (final ({GridPos pos, TileColor color}) c in controller.engine.lastCleared) {
+      _burst.spawnBurst(
+        x: _ox + (c.pos.x * _cell) + (_cell / 2),
+        y: _oy + (c.pos.y * _cell) + (_cell / 2),
+        color: gemColors[c.color]!,
+        sizeBase: _cell * 0.12,
+        sizeJitter: _cell * 0.1,
+      );
+    }
+  }
+
+  void _pulse(String text) {
+    _pulseText = text;
+    _pulseElapsed = 0;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    _clock += dt;
+    if (_flash > 0) {
+      _flash = math.max(0, _flash - (dt * 2.6));
+    }
+    if (_shake > 0) {
+      _shake = math.max(0, _shake - (dt * 3.4));
+    }
+    if (_pulseText != null) {
+      _pulseElapsed += dt;
+      if (_pulseElapsed > 1.0) {
+        _pulseText = null;
+      }
+    }
+    if (_scorePopText != null) {
+      _scorePopElapsed += dt;
+      if (_scorePopElapsed > 0.9) {
+        _scorePopText = null;
+      }
+    }
+    final int score = controller.score;
+    if (score > _lastScore) {
+      _scorePopText = '+${score - _lastScore}';
+      _scorePopElapsed = 0;
+    }
+    _lastScore = score;
+    _burst.update(dt);
+  }
+
+  @override
+  void render(Canvas canvas) {
+    super.render(canvas);
+    if (size.x <= 0 || size.y <= 0) {
+      return;
+    }
+    final TileGrid grid = controller.grid;
+    final double cell = math.min(size.x / _cols, size.y / _rows);
+    final double boardW = cell * _cols;
+    final double boardH = cell * _rows;
+    final double ox = (size.x - boardW) / 2;
+    final double oy = (size.y - boardH) / 2;
+    _ox = ox;
+    _oy = oy;
+    _cell = cell;
+
+    final double sx = _shake > 0 ? math.sin(_shake * 51) * _shake * 6 : 0;
+    final double sy = _shake > 0 ? math.cos(_shake * 59) * _shake * 6 : 0;
+    canvas.save();
+    canvas.translate(sx, sy);
+
+    _renderBackground(canvas, ox, oy, boardW, boardH);
+
+    for (int y = 0; y < _rows; y++) {
+      for (int x = 0; x < _cols; x++) {
+        final TileColor? color = grid.at(x, y);
+        if (color != null) {
+          _paintGem(canvas, ox, oy, x, y, cell, gemColors[color]!);
+        }
+      }
+    }
+
+    final GridPos? sel = _selected;
+    if (sel != null) {
+      _paintSelection(canvas, ox, oy, sel, cell);
+    }
+
+    if (_flash > 0) {
+      final double alpha = (_flash * 0.35).clamp(0, 0.5).toDouble();
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(ox, oy, boardW, boardH),
+          const Radius.circular(14),
+        ),
+        Paint()..color = Color.fromRGBO(180, 235, 255, alpha),
+      );
+    }
+
+    canvas.restore();
+
+    _burst.render(canvas);
+    _renderScorePop(canvas, ox, oy, boardW, boardH);
+    _renderPulse(canvas, ox, oy, boardW, boardH);
+  }
+
+  void _renderBackground(
+    Canvas canvas,
+    double ox,
+    double oy,
+    double boardW,
+    double boardH,
+  ) {
+    final Rect rect = Rect.fromLTWH(ox, oy, boardW, boardH);
+    final RRect rr = RRect.fromRectAndRadius(rect, const Radius.circular(14));
+    canvas.drawRRect(
+      rr,
+      Paint()
+        ..shader = const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: <Color>[Color(0xFF101A33), Color(0xFF0B1326)],
+        ).createShader(rect),
+    );
+    canvas.drawRRect(
+      rr,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.4
+        ..color = const Color(0x99B6E6FF),
+    );
+  }
+
+  void _paintGem(
+    Canvas canvas,
+    double ox,
+    double oy,
+    int x,
+    int y,
+    double cell,
+    Color color,
+  ) {
+    final double inset = cell * 0.1;
+    final Rect rect = Rect.fromLTWH(
+      ox + (x * cell) + inset,
+      oy + (y * cell) + inset,
+      cell - (inset * 2),
+      cell - (inset * 2),
+    );
+    final RRect rr = RRect.fromRectAndRadius(rect, Radius.circular(cell * 0.28));
+
+    final Color light = Color.lerp(color, Colors.white, 0.4) ?? color;
+    final Color dark = Color.lerp(color, const Color(0xFF0A1222), 0.42) ?? color;
+    canvas.drawRRect(
+      rr,
+      Paint()
+        ..shader = LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[light, color, dark],
+          stops: const <double>[0, 0.5, 1],
+        ).createShader(rect),
+    );
+    canvas.drawRRect(
+      rr,
+      Paint()
+        ..shader = const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: <Color>[Color(0x66FFFFFF), Color(0x00FFFFFF)],
+          stops: <double>[0, 0.5],
+        ).createShader(rect),
+    );
+    canvas.drawRRect(
+      rr,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1
+        ..color = Color.lerp(color, Colors.white, 0.5) ?? color,
+    );
+  }
+
+  void _paintSelection(
+    Canvas canvas,
+    double ox,
+    double oy,
+    GridPos sel,
+    double cell,
+  ) {
+    final double pulse = 0.6 + (0.4 * math.sin(_clock * 7));
+    final double pad = cell * 0.04;
+    final Rect rect = Rect.fromLTWH(
+      ox + (sel.x * cell) + pad,
+      oy + (sel.y * cell) + pad,
+      cell - (pad * 2),
+      cell - (pad * 2),
+    );
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(rect, Radius.circular(cell * 0.28)),
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = math.max(2.0, cell * 0.08)
+        ..color = Colors.white.withValues(alpha: (0.55 + 0.45 * pulse).clamp(0, 1).toDouble()),
+    );
+  }
+
+  void _renderScorePop(
+    Canvas canvas,
+    double ox,
+    double oy,
+    double boardW,
+    double boardH,
+  ) {
+    final String? text = _scorePopText;
+    if (text == null) {
+      return;
+    }
+    final double t = (_scorePopElapsed / 0.9).clamp(0, 1).toDouble();
+    final double opacity = (1 - t).clamp(0, 1).toDouble();
+    final TextPainter painter = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(
+          color: Color.fromRGBO(214, 255, 224, opacity),
+          fontSize: 24,
+          fontWeight: FontWeight.w800,
+          shadows: <Shadow>[
+            Shadow(
+              color: Color.fromRGBO(95, 224, 138, opacity * 0.9),
+              blurRadius: 14,
+            ),
+          ],
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: boardW);
+    painter.paint(
+      canvas,
+      Offset(ox + ((boardW - painter.width) / 2), oy + (boardH * 0.42) - (t * 40)),
+    );
+  }
+
+  void _renderPulse(
+    Canvas canvas,
+    double ox,
+    double oy,
+    double boardW,
+    double boardH,
+  ) {
+    final String? text = _pulseText;
+    if (text == null) {
+      return;
+    }
+    final double t = (_pulseElapsed / 1.0).clamp(0, 1).toDouble();
+    final double opacity = (1 - t).clamp(0, 1).toDouble();
+    final TextPainter painter = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(
+          color: Color.fromRGBO(196, 240, 255, opacity),
+          fontSize: 30,
+          fontWeight: FontWeight.w800,
+          letterSpacing: 1.4,
+          shadows: <Shadow>[
+            Shadow(
+              color: Color.fromRGBO(86, 212, 255, opacity * 0.9),
+              blurRadius: 18,
+            ),
+          ],
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(maxWidth: boardW);
+    painter.paint(
+      canvas,
+      Offset(ox + ((boardW - painter.width) / 2), oy + (boardH * 0.32) - (t * 20)),
+    );
+  }
+}

--- a/apps/mobile/lib/features/match3/presentation/match3_screen.dart
+++ b/apps/mobile/lib/features/match3/presentation/match3_screen.dart
@@ -1,0 +1,361 @@
+import 'dart:async';
+
+import 'package:flame/game.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/audio/music_controller.dart';
+import '../../../core/device/haptics_controller.dart';
+import '../../../core/di/di_container.dart';
+import '../../../data/analytics/analytics_tracker.dart';
+import '../../../domain/match3/tile.dart';
+import '../../../ui/theme/app_theme.dart';
+import '../../../ui/widgets/nebula_background.dart';
+import '../../game_loop/audio/game_sfx_player.dart';
+import '../application/match3_controller.dart';
+import '../application/match3_session_store.dart';
+import 'match3_game.dart';
+
+class Match3Screen extends StatefulWidget {
+  const Match3Screen({super.key});
+
+  @override
+  State<Match3Screen> createState() => _Match3ScreenState();
+}
+
+class _Match3ScreenState extends State<Match3Screen>
+    with WidgetsBindingObserver {
+  late final GameSfxPlayer _sfx;
+  late final HapticsController _haptics;
+  late final MusicController _music;
+  late final Match3Controller _controller;
+  late final Match3FlameGame _game;
+  bool _isDisposed = false;
+
+  // Swipe tracking (in GameWidget-local pixels).
+  GridPos? _panStartCell;
+  Offset? _panStartOffset;
+  Offset? _panLastOffset;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _sfx = sl<GameSfxPlayer>();
+    _haptics = sl<HapticsController>();
+    _music = sl<MusicController>();
+    _controller = Match3Controller(
+      sfx: _sfx,
+      haptics: _haptics,
+      analyticsTracker: sl<AnalyticsTracker>(),
+      store: sl<Match3SessionStore>(),
+    );
+    _game = Match3FlameGame(controller: _controller);
+    unawaited(_sfx.preload());
+    unawaited(_controller.initialize());
+    unawaited(_initMusic());
+  }
+
+  Future<void> _initMusic() async {
+    await _music.loadPreference();
+    if (!mounted) {
+      return;
+    }
+    await _music.play();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    WidgetsBinding.instance.removeObserver(this);
+    _game.pauseEngine();
+    unawaited(_music.stop());
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_isDisposed) {
+      return;
+    }
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _game.resumeEngine();
+        unawaited(_sfx.onAppResumed());
+        unawaited(_music.resume());
+        break;
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+        _controller.saveActiveGame();
+        _game.pauseEngine();
+        unawaited(_music.pause());
+        break;
+    }
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    final GridPos? cell = _game.cellAt(details.localPosition);
+    if (cell != null) {
+      _game.onCellTapped(cell);
+    }
+  }
+
+  void _onPanStart(DragStartDetails details) {
+    _panStartOffset = details.localPosition;
+    _panLastOffset = details.localPosition;
+    _panStartCell = _game.cellAt(details.localPosition);
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    _panLastOffset = details.localPosition;
+  }
+
+  void _onPanEnd(DragEndDetails details) {
+    final GridPos? start = _panStartCell;
+    final Offset? from = _panStartOffset;
+    final Offset? to = _panLastOffset;
+    _panStartCell = null;
+    _panStartOffset = null;
+    _panLastOffset = null;
+    if (start == null || from == null || to == null) {
+      return;
+    }
+    final double dx = to.dx - from.dx;
+    final double dy = to.dy - from.dy;
+    // Require a deliberate drag before treating it as a swipe.
+    if (dx.abs() < 12 && dy.abs() < 12) {
+      return;
+    }
+    if (dx.abs() >= dy.abs()) {
+      _game.onSwipe(start, dx > 0 ? 1 : -1, 0);
+    } else {
+      _game.onSwipe(start, 0, dy > 0 ? 1 : -1);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Match 3',
+          style: TextStyle(
+            color: Color(0xFFC5F2FF),
+            fontWeight: FontWeight.w500,
+            fontSize: 24,
+            letterSpacing: 0.3,
+            shadows: <Shadow>[
+              Shadow(color: Color(0x7A53D5FF), blurRadius: 16),
+              Shadow(color: Color(0x6640B9FF), blurRadius: 30),
+            ],
+          ),
+        ),
+      ),
+      body: Stack(
+        children: <Widget>[
+          const Positioned.fill(child: NebulaBackground()),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Column(
+                children: <Widget>[
+                  AnimatedBuilder(
+                    animation: _controller,
+                    builder: (BuildContext context, Widget? child) {
+                      return _Match3Hud(controller: _controller);
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  Expanded(
+                    child: Center(
+                      child: AspectRatio(
+                        aspectRatio: 1,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(14),
+                          child: GestureDetector(
+                            onTapUp: _onTapUp,
+                            onPanStart: _onPanStart,
+                            onPanUpdate: _onPanUpdate,
+                            onPanEnd: _onPanEnd,
+                            child: GameWidget<Match3FlameGame>(game: _game),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const _SwipeHint(),
+                ],
+              ),
+            ),
+          ),
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (BuildContext context, Widget? child) {
+              if (!_controller.isGameOver) {
+                return const SizedBox.shrink();
+              }
+              return Positioned.fill(
+                child: ColoredBox(
+                  color: const Color(0xB20A1222),
+                  child: Center(
+                    child: _GameOverCard(
+                      score: _controller.score,
+                      best: _controller.bestScore,
+                      moves: _controller.movesUsed,
+                      onRestart: _controller.restart,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Match3Hud extends StatelessWidget {
+  const _Match3Hud({required this.controller});
+
+  final Match3Controller controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final int? movesLeft = controller.movesLeft;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: LuminaPalette.panel,
+        border: Border.all(color: LuminaPalette.panelBorder),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(child: _Metric(label: 'Score', value: '${controller.score}')),
+          Expanded(child: _Metric(label: 'Best', value: '${controller.bestScore}')),
+          Expanded(
+            child: _Metric(
+              label: 'Moves',
+              value: movesLeft == null ? '∞' : '$movesLeft',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          label,
+          style: const TextStyle(
+            color: LuminaPalette.textSecondary,
+            fontSize: 11,
+            letterSpacing: 0.3,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: const TextStyle(
+            color: Color(0xFFD5F4FF),
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            shadows: <Shadow>[Shadow(color: Color(0x9252CBFF), blurRadius: 10)],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SwipeHint extends StatelessWidget {
+  const _SwipeHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text(
+      'Tap two adjacent gems — or swipe one — to match 3+ in a row.',
+      textAlign: TextAlign.center,
+      style: TextStyle(color: LuminaPalette.textSecondary, fontSize: 12),
+    );
+  }
+}
+
+class _GameOverCard extends StatelessWidget {
+  const _GameOverCard({
+    required this.score,
+    required this.best,
+    required this.moves,
+    required this.onRestart,
+  });
+
+  final int score;
+  final int best;
+  final int moves;
+  final VoidCallback onRestart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 32),
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: LuminaPalette.panel,
+        border: Border.all(color: LuminaPalette.panelBorder),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const Text(
+            'Out of Moves',
+            style: TextStyle(
+              color: Color(0xFFFFC56B),
+              fontSize: 26,
+              fontWeight: FontWeight.w800,
+              shadows: <Shadow>[Shadow(color: Color(0x66FFC56B), blurRadius: 18)],
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Score $score   ·   Best $best',
+            style: const TextStyle(
+              color: Color(0xFFD5F4FF),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Moves played $moves',
+            style: const TextStyle(color: LuminaPalette.textSecondary),
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: onRestart,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('Play Again'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/ui/screens/home_screen.dart
+++ b/apps/mobile/lib/ui/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../features/game_loop/presentation/game_loop_screen.dart';
 import '../../features/settings/presentation/settings_screen.dart';
+import '../../features/match3/presentation/match3_screen.dart';
 import '../../features/store/presentation/store_screen.dart';
 import '../../features/tetris/presentation/tetris_screen.dart';
 import '../theme/app_theme.dart';
@@ -155,6 +156,25 @@ class HomeScreen extends StatelessWidget {
                         },
                         icon: const Icon(Icons.grid_view_rounded),
                         label: const Text('Play Tetris'),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        style: FilledButton.styleFrom(
+                          backgroundColor: const Color(0xFF2E9E6B),
+                          foregroundColor: Colors.white,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => const Match3Screen(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.diamond_rounded),
+                        label: const Text('Play Match 3'),
                       ),
                     ),
                     const SizedBox(height: 10),

--- a/apps/mobile/test/unit/domain/match3/cascade_resolver_test.dart
+++ b/apps/mobile/test/unit/domain/match3/cascade_resolver_test.dart
@@ -1,0 +1,99 @@
+import 'package:block_puzzle_mobile/domain/match3/cascade_resolver.dart';
+import 'package:block_puzzle_mobile/domain/match3/match_detector.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_spawner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const TileColor r = TileColor.ruby;
+const TileColor m = TileColor.amber;
+const TileColor c = TileColor.citrine;
+const TileColor e = TileColor.emerald;
+
+TileGrid g(List<List<TileColor>> rows) {
+  final int h = rows.length;
+  final int w = rows.first.length;
+  return TileGrid(
+    width: w,
+    height: h,
+    cells: <TileColor?>[for (final List<TileColor> row in rows) ...row],
+  );
+}
+
+void main() {
+  const MatchDetector detector = MatchDetector();
+
+  group('CascadeResolver.applyGravity', () {
+    test('non-null tiles fall to the bottom, holes rise to the top', () {
+      final CascadeResolver resolver =
+          CascadeResolver(spawner: TileSpawner(seed: 1));
+      // Column: r (top), hole, c (bottom).
+      final TileGrid grid =
+          TileGrid(width: 1, height: 3, cells: <TileColor?>[r, null, c]);
+      final TileGrid fallen = resolver.applyGravity(grid);
+      expect(fallen.at(0, 0), isNull);
+      expect(fallen.at(0, 1), r);
+      expect(fallen.at(0, 2), c);
+    });
+  });
+
+  group('CascadeResolver.resolve', () {
+    test('clears a single match and settles to a match-free board', () {
+      final CascadeResolver resolver =
+          CascadeResolver(spawner: TileSpawner(seed: 5));
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, r, r],
+        <TileColor>[m, c, e],
+        <TileColor>[c, e, m],
+      ]);
+
+      final CascadeOutcome outcome = resolver.resolve(grid);
+
+      expect(outcome.hadMatch, isTrue);
+      expect(outcome.steps.first.cleared, <GridPos>{
+        const GridPos(0, 0),
+        const GridPos(1, 0),
+        const GridPos(2, 0),
+      });
+      expect(outcome.totalCleared, greaterThanOrEqualTo(3));
+      expect(outcome.totalScore, greaterThan(0));
+      // Invariant: the settled board never contains a match.
+      expect(detector.hasMatch(outcome.grid), isFalse);
+      expect(outcome.grid.isFull, isTrue);
+    });
+
+    test('a board with no match resolves to itself with no steps', () {
+      final CascadeResolver resolver =
+          CascadeResolver(spawner: TileSpawner(seed: 5));
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, m, r],
+        <TileColor>[m, r, m],
+        <TileColor>[r, m, r],
+      ]);
+      final CascadeOutcome outcome = resolver.resolve(grid);
+      expect(outcome.hadMatch, isFalse);
+      expect(outcome.totalScore, 0);
+    });
+
+    test('a falling tile chains into a second match (cascade)', () {
+      // L-shape clears 5 cells; differential column drops align a new amber
+      // triple along the bottom row, guaranteeing at least a 2-deep cascade.
+      final CascadeResolver resolver =
+          CascadeResolver(spawner: TileSpawner(seed: 11));
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[m, c, e, m],
+        <TileColor>[r, e, c, r],
+        <TileColor>[r, m, m, c],
+        <TileColor>[r, r, r, e],
+      ]);
+
+      final CascadeOutcome outcome = resolver.resolve(grid);
+
+      expect(outcome.cascadeCount, greaterThanOrEqualTo(2));
+      expect(outcome.totalCleared, greaterThanOrEqualTo(8));
+      // Deeper cascade steps carry a higher level (multiplier).
+      expect(outcome.steps[1].cascadeLevel, 2);
+      expect(detector.hasMatch(outcome.grid), isFalse);
+    });
+  });
+}

--- a/apps/mobile/test/unit/domain/match3/match3_engine_test.dart
+++ b/apps/mobile/test/unit/domain/match3/match3_engine_test.dart
@@ -1,0 +1,140 @@
+import 'package:block_puzzle_mobile/domain/match3/match3_engine.dart';
+import 'package:block_puzzle_mobile/domain/match3/match_detector.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const TileColor r = TileColor.ruby;
+const TileColor m = TileColor.amber;
+const TileColor c = TileColor.citrine;
+const TileColor e = TileColor.emerald;
+
+/// A settled 4×4 board with no pre-existing match. Swapping (2,0)<->(2,1)
+/// completes the top row into r,r,r.
+TileGrid craftBoard() => TileGrid(
+      width: 4,
+      height: 4,
+      cells: <TileColor?>[
+        r, r, e, m, // y0
+        m, c, r, c, // y1
+        c, m, c, e, // y2
+        e, c, m, r, // y3
+      ],
+    );
+
+Map<String, Object?> craftSnapshot({int score = 0, int movesUsed = 0}) =>
+    <String, Object?>{
+      'grid': craftBoard().toJson(),
+      'score': score,
+      'moves_used': movesUsed,
+    };
+
+void main() {
+  const MatchDetector detector = MatchDetector();
+
+  group('Match3Engine start', () {
+    test('fills a playable board with no pre-existing match', () {
+      final Match3Engine engine = Match3Engine(seed: 7)..start();
+      expect(engine.isStarted, isTrue);
+      expect(engine.grid.isFull, isTrue);
+      expect(detector.hasMatch(engine.grid), isFalse);
+      expect(engine.hasPossibleMove(), isTrue);
+    });
+
+    test('is deterministic for a given seed', () {
+      final Match3Engine a = Match3Engine(seed: 7)..start();
+      final Match3Engine b = Match3Engine(seed: 7)..start();
+      for (int y = 0; y < a.height; y++) {
+        for (int x = 0; x < a.width; x++) {
+          expect(a.grid.at(x, y), b.grid.at(x, y));
+        }
+      }
+    });
+  });
+
+  group('Match3Engine swap', () {
+    test('a legal swap scores, consumes a move, and emits a match event', () {
+      final Match3Engine engine =
+          Match3Engine(width: 4, height: 4)..restore(craftSnapshot());
+      engine.drainEvents();
+
+      final bool ok =
+          engine.swap(const GridPos(2, 0), const GridPos(2, 1));
+
+      expect(ok, isTrue);
+      expect(engine.score, greaterThan(0));
+      expect(engine.movesUsed, 1);
+      final List<Match3EventType> types =
+          engine.drainEvents().map((Match3Event ev) => ev.type).toList();
+      expect(types, contains(Match3EventType.swap));
+      expect(types, contains(Match3EventType.match));
+    });
+
+    test('an adjacent swap that makes no match is reverted', () {
+      final Match3Engine engine =
+          Match3Engine(width: 4, height: 4)..restore(craftSnapshot());
+      engine.drainEvents();
+
+      final bool ok =
+          engine.swap(const GridPos(0, 0), const GridPos(0, 1));
+
+      expect(ok, isFalse);
+      expect(engine.score, 0);
+      expect(engine.movesUsed, 0);
+      expect(
+        engine.drainEvents().map((Match3Event ev) => ev.type),
+        contains(Match3EventType.invalidSwap),
+      );
+    });
+
+    test('a non-adjacent swap is a silent no-op', () {
+      final Match3Engine engine =
+          Match3Engine(width: 4, height: 4)..restore(craftSnapshot());
+      engine.drainEvents();
+
+      final bool ok =
+          engine.swap(const GridPos(0, 0), const GridPos(3, 3));
+
+      expect(ok, isFalse);
+      expect(engine.movesUsed, 0);
+      expect(engine.drainEvents(), isEmpty);
+    });
+
+    test('reaching the move limit ends the run', () {
+      final Match3Engine engine = Match3Engine(width: 4, height: 4, moveLimit: 1)
+        ..restore(craftSnapshot());
+      engine.drainEvents();
+
+      engine.swap(const GridPos(2, 0), const GridPos(2, 1));
+
+      expect(engine.isGameOver, isTrue);
+      expect(engine.movesLeft, 0);
+      expect(
+        engine.drainEvents().map((Match3Event ev) => ev.type),
+        contains(Match3EventType.gameOver),
+      );
+      // No further swaps are accepted after game over.
+      expect(engine.swap(const GridPos(0, 0), const GridPos(1, 0)), isFalse);
+    });
+  });
+
+  group('Match3Engine snapshot', () {
+    test('round-trips score, moves, and the board', () {
+      final Match3Engine engine =
+          Match3Engine(width: 4, height: 4)..restore(craftSnapshot());
+      engine.swap(const GridPos(2, 0), const GridPos(2, 1));
+      final Map<String, Object?> snap = engine.toSnapshot();
+
+      final Match3Engine restored =
+          Match3Engine(width: 4, height: 4)..restore(snap);
+      expect(restored.score, engine.score);
+      expect(restored.movesUsed, engine.movesUsed);
+      expect(restored.isStarted, isTrue);
+      for (int y = 0; y < 4; y++) {
+        for (int x = 0; x < 4; x++) {
+          expect(restored.grid.at(x, y), engine.grid.at(x, y));
+        }
+      }
+    });
+  });
+}

--- a/apps/mobile/test/unit/domain/match3/match_detector_test.dart
+++ b/apps/mobile/test/unit/domain/match3/match_detector_test.dart
@@ -1,0 +1,76 @@
+import 'package:block_puzzle_mobile/domain/match3/match_detector.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const TileColor r = TileColor.ruby;
+const TileColor m = TileColor.amber;
+const TileColor c = TileColor.citrine;
+const TileColor e = TileColor.emerald;
+
+/// Builds a grid from rows listed top (y=0) to bottom.
+TileGrid g(List<List<TileColor>> rows) {
+  final int h = rows.length;
+  final int w = rows.first.length;
+  return TileGrid(
+    width: w,
+    height: h,
+    cells: <TileColor?>[for (final List<TileColor> row in rows) ...row],
+  );
+}
+
+void main() {
+  const MatchDetector detector = MatchDetector();
+
+  group('MatchDetector', () {
+    test('detects a horizontal run of three', () {
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, r, r, m],
+      ]);
+      final List<TileMatch> matches = detector.findMatches(grid);
+      expect(matches, hasLength(1));
+      expect(matches.single.horizontal, isTrue);
+      expect(matches.single.length, 3);
+      expect(matches.single.color, r);
+      expect(detector.hasMatch(grid), isTrue);
+    });
+
+    test('detects a vertical run of three', () {
+      final TileGrid grid =
+          TileGrid(width: 1, height: 3, cells: <TileColor?>[r, r, r]);
+      final List<TileMatch> matches = detector.findMatches(grid);
+      expect(matches, hasLength(1));
+      expect(matches.single.horizontal, isFalse);
+      expect(matches.single.length, 3);
+    });
+
+    test('a checkerboard has no matches', () {
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, m, r],
+        <TileColor>[m, r, m],
+        <TileColor>[r, m, r],
+      ]);
+      expect(detector.findMatches(grid), isEmpty);
+      expect(detector.hasMatch(grid), isFalse);
+    });
+
+    test('an L-shape reports two runs and a 5-cell union', () {
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, m, c],
+        <TileColor>[r, m, c],
+        <TileColor>[r, r, r],
+      ]);
+      expect(detector.findMatches(grid), hasLength(2));
+      expect(detector.matchedCells(grid), hasLength(5));
+    });
+
+    test('a run of four is a single length-4 match', () {
+      final TileGrid grid = g(<List<TileColor>>[
+        <TileColor>[r, r, r, r],
+      ]);
+      final List<TileMatch> matches = detector.findMatches(grid);
+      expect(matches, hasLength(1));
+      expect(matches.single.length, 4);
+    });
+  });
+}

--- a/apps/mobile/test/unit/domain/match3/swap_validator_test.dart
+++ b/apps/mobile/test/unit/domain/match3/swap_validator_test.dart
@@ -1,0 +1,76 @@
+import 'package:block_puzzle_mobile/domain/match3/swap_validator.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const TileColor r = TileColor.ruby;
+const TileColor m = TileColor.amber;
+const TileColor c = TileColor.citrine;
+const TileColor e = TileColor.emerald;
+
+TileGrid g(List<List<TileColor>> rows) {
+  final int h = rows.length;
+  final int w = rows.first.length;
+  return TileGrid(
+    width: w,
+    height: h,
+    cells: <TileColor?>[for (final List<TileColor> row in rows) ...row],
+  );
+}
+
+void main() {
+  const SwapValidator validator = SwapValidator();
+
+  group('SwapValidator.isAdjacent', () {
+    test('orthogonal neighbors are adjacent', () {
+      expect(validator.isAdjacent(const GridPos(0, 0), const GridPos(1, 0)),
+          isTrue);
+      expect(validator.isAdjacent(const GridPos(0, 0), const GridPos(0, 1)),
+          isTrue);
+    });
+
+    test('diagonal, same, and distant cells are not adjacent', () {
+      expect(validator.isAdjacent(const GridPos(0, 0), const GridPos(1, 1)),
+          isFalse);
+      expect(validator.isAdjacent(const GridPos(0, 0), const GridPos(0, 0)),
+          isFalse);
+      expect(validator.isAdjacent(const GridPos(0, 0), const GridPos(2, 0)),
+          isFalse);
+    });
+  });
+
+  group('SwapValidator.producesMatch', () {
+    // No pre-existing match; swapping (2,0)<->(2,1) completes row 0 into r,r,r.
+    final TileGrid grid = g(<List<TileColor>>[
+      <TileColor>[r, r, m],
+      <TileColor>[c, m, r],
+      <TileColor>[m, c, e],
+    ]);
+
+    test('true when the swap completes a run', () {
+      expect(
+        validator.producesMatch(grid, const GridPos(2, 0), const GridPos(2, 1)),
+        isTrue,
+      );
+      expect(
+        validator.isLegalSwap(grid, const GridPos(2, 0), const GridPos(2, 1)),
+        isTrue,
+      );
+    });
+
+    test('false when the swap creates no run', () {
+      expect(
+        validator.producesMatch(grid, const GridPos(0, 0), const GridPos(1, 0)),
+        isFalse,
+      );
+    });
+
+    test('a non-adjacent match-producing pair is not a legal swap', () {
+      // (2,1) holds r; (0,0)/(1,0) are r — but they are not adjacent to it.
+      expect(
+        validator.isLegalSwap(grid, const GridPos(0, 0), const GridPos(2, 1)),
+        isFalse,
+      );
+    });
+  });
+}

--- a/apps/mobile/test/unit/domain/match3/tile_grid_test.dart
+++ b/apps/mobile/test/unit/domain/match3/tile_grid_test.dart
@@ -1,0 +1,67 @@
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const TileColor r = TileColor.ruby;
+const TileColor m = TileColor.amber;
+const TileColor c = TileColor.citrine;
+const TileColor e = TileColor.emerald;
+
+void main() {
+  group('TileGrid', () {
+    test('at / inBounds respect the rectangle', () {
+      final TileGrid grid =
+          TileGrid(width: 2, height: 2, cells: <TileColor?>[r, m, c, e]);
+      expect(grid.at(0, 0), r);
+      expect(grid.at(1, 1), e);
+      expect(grid.inBounds(2, 0), isFalse);
+      expect(grid.at(2, 0), isNull);
+    });
+
+    test('swapped exchanges two cells without mutating the original', () {
+      final TileGrid grid =
+          TileGrid(width: 2, height: 2, cells: <TileColor?>[r, m, c, e]);
+      final TileGrid swapped =
+          grid.swapped(const GridPos(0, 0), const GridPos(1, 0));
+      expect(swapped.at(0, 0), m);
+      expect(swapped.at(1, 0), r);
+      // Original is untouched.
+      expect(grid.at(0, 0), r);
+      expect(grid.at(1, 0), m);
+    });
+
+    test('clearedAt nulls the given cells', () {
+      final TileGrid grid =
+          TileGrid(width: 2, height: 2, cells: <TileColor?>[r, m, c, e]);
+      final TileGrid cleared =
+          grid.clearedAt(<GridPos>[const GridPos(0, 0), const GridPos(1, 1)]);
+      expect(cleared.at(0, 0), isNull);
+      expect(cleared.at(1, 1), isNull);
+      expect(cleared.at(1, 0), m);
+      expect(cleared.isFull, isFalse);
+    });
+
+    test('isFull is true only when every cell is set', () {
+      expect(
+        TileGrid(width: 2, height: 1, cells: <TileColor?>[r, m]).isFull,
+        isTrue,
+      );
+      expect(
+        TileGrid(width: 2, height: 1, cells: <TileColor?>[r, null]).isFull,
+        isFalse,
+      );
+    });
+
+    test('toJson / fromJson round-trips', () {
+      final TileGrid grid =
+          TileGrid(width: 2, height: 2, cells: <TileColor?>[r, null, c, e]);
+      final TileGrid restored = TileGrid.fromJson(grid.toJson());
+      expect(restored.width, 2);
+      expect(restored.height, 2);
+      expect(restored.at(0, 0), r);
+      expect(restored.at(1, 0), isNull);
+      expect(restored.at(0, 1), c);
+      expect(restored.at(1, 1), e);
+    });
+  });
+}

--- a/apps/mobile/test/unit/domain/match3/tile_spawner_test.dart
+++ b/apps/mobile/test/unit/domain/match3/tile_spawner_test.dart
@@ -1,0 +1,36 @@
+import 'package:block_puzzle_mobile/domain/match3/match_detector.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_grid.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile_spawner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const MatchDetector detector = MatchDetector();
+
+  group('TileSpawner.fillInitial', () {
+    test('produces a board with no pre-existing match', () {
+      for (final int seed in <int>[1, 7, 42, 1000]) {
+        final TileGrid grid = TileSpawner(seed: seed).fillInitial(8, 8);
+        expect(grid.isFull, isTrue);
+        expect(detector.hasMatch(grid), isFalse,
+            reason: 'seed $seed produced a starting match');
+      }
+    });
+
+    test('is deterministic for a given seed', () {
+      final TileGrid a = TileSpawner(seed: 99).fillInitial(8, 8);
+      final TileGrid b = TileSpawner(seed: 99).fillInitial(8, 8);
+      for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 8; x++) {
+          expect(a.at(x, y), b.at(x, y));
+        }
+      }
+    });
+
+    test('refill fills every hole', () {
+      final TileSpawner spawner = TileSpawner(seed: 3);
+      final TileGrid holed = spawner.fillInitial(4, 4).withCell(1, 1, null);
+      expect(holed.isFull, isFalse);
+      expect(spawner.refill(holed).isFull, isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/unit/features/match3/match3_controller_test.dart
+++ b/apps/mobile/test/unit/features/match3/match3_controller_test.dart
@@ -1,0 +1,168 @@
+import 'package:block_puzzle_mobile/core/device/haptics_controller.dart';
+import 'package:block_puzzle_mobile/core/logging/app_logger.dart';
+import 'package:block_puzzle_mobile/data/analytics/analytics_tracker.dart';
+import 'package:block_puzzle_mobile/domain/match3/match3_engine.dart';
+import 'package:block_puzzle_mobile/domain/match3/tile.dart';
+import 'package:block_puzzle_mobile/features/game_loop/audio/game_sfx_player.dart';
+import 'package:block_puzzle_mobile/features/match3/application/match3_controller.dart';
+import 'package:block_puzzle_mobile/features/match3/application/match3_session_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late _MemoryAnalytics analytics;
+  late HapticsController haptics;
+  late _NoopSfx sfx;
+
+  setUp(() {
+    analytics = _MemoryAnalytics();
+    haptics = HapticsController()..isEnabled = false; // no platform calls
+    sfx = _NoopSfx();
+  });
+
+  Match3Controller makeController({
+    int seed = 5,
+    Map<String, Object?>? snapshot,
+    _FakeStore? store,
+  }) {
+    return Match3Controller(
+      seed: seed,
+      sfx: sfx,
+      haptics: haptics,
+      analyticsTracker: analytics,
+      store: store ?? _FakeStore(snapshot: snapshot),
+    );
+  }
+
+  Map<String, Object?> paramsOf(String event) =>
+      analytics.tracked.firstWhere((_Tracked t) => t.name == event).params;
+
+  test('initialize starts a fresh round and emits game_start(match3)', () async {
+    final Match3Controller controller = makeController();
+    await controller.initialize();
+
+    expect(controller.isGameOver, isFalse);
+    expect(controller.score, 0);
+    expect(analytics.names, contains('game_start'));
+    final Map<String, Object?> p = paramsOf('game_start');
+    expect(p['game_id'], 'match3');
+    expect(p['mode'], 'match3');
+    expect(p['resumed'], false);
+  });
+
+  test('a legal swap scores, consumes a move, and tracks line_clear', () async {
+    final Match3Controller controller = makeController();
+    await controller.initialize();
+
+    final (GridPos, GridPos)? hint = controller.engine.findHint();
+    expect(hint, isNotNull);
+    final bool ok = controller.trySwap(hint!.$1, hint.$2);
+
+    expect(ok, isTrue);
+    expect(controller.score, greaterThan(0));
+    expect(controller.movesUsed, 1);
+    expect(analytics.names, contains('line_clear'));
+    expect(paramsOf('line_clear')['game_id'], 'match3');
+  });
+
+  test('resuming a snapshot flags game_start.resumed and keeps the score',
+      () async {
+    final Match3Engine seeded = Match3Engine(seed: 9)..start();
+    final Match3Engine scored = Match3Engine(seed: 9)..restore(seeded.toSnapshot());
+    final (GridPos, GridPos)? hint = scored.findHint();
+    scored.swap(hint!.$1, hint.$2); // bank some score into the snapshot
+    final Map<String, Object?> snapshot = scored.toSnapshot();
+
+    final Match3Controller controller = makeController(snapshot: snapshot);
+    await controller.initialize();
+
+    expect(paramsOf('game_start')['resumed'], true);
+    expect(controller.score, scored.score);
+  });
+
+  test('restart emits a new game_start and resets the run', () async {
+    final Match3Controller controller = makeController();
+    await controller.initialize();
+    final (GridPos, GridPos)? hint = controller.engine.findHint();
+    controller.trySwap(hint!.$1, hint.$2);
+    expect(controller.movesUsed, 1);
+
+    controller.restart();
+
+    expect(controller.movesUsed, 0);
+    expect(controller.score, 0);
+    expect(analytics.names.where((String e) => e == 'game_start').length, 2);
+  });
+}
+
+class _FakeStore extends Match3SessionStore {
+  _FakeStore({this.snapshot}) : super(logger: AppLogger());
+
+  Map<String, Object?>? snapshot;
+
+  @override
+  Future<int> loadBestScore() async => 0;
+
+  @override
+  Future<Map<String, Object?>?> loadSnapshot() async => snapshot;
+
+  @override
+  Future<void> saveSnapshot(Map<String, Object?> s) async => snapshot = s;
+
+  @override
+  Future<void> clearSnapshot() async => snapshot = null;
+
+  @override
+  Future<void> saveBestScore(int s) async {}
+}
+
+class _NoopSfx implements GameSfxPlayer {
+  @override
+  bool isEnabled = true;
+
+  @override
+  Future<void> preload() async {}
+  @override
+  Future<void> onAppResumed() async {}
+  @override
+  Future<void> playPiecePlaced() async {}
+  @override
+  Future<void> playInvalidMove() async {}
+  @override
+  Future<void> playLineClear({required int clearedLines}) async {}
+  @override
+  Future<void> playCombo({required int comboStreak}) async {}
+  @override
+  Future<void> playRotate() async {}
+  @override
+  Future<void> playHold() async {}
+  @override
+  Future<void> playHardDrop() async {}
+  @override
+  Future<void> playGameOver() async {}
+}
+
+class _MemoryAnalytics implements AnalyticsTracker {
+  final List<_Tracked> tracked = <_Tracked>[];
+
+  List<String> get names =>
+      tracked.map((_Tracked t) => t.name).toList(growable: false);
+
+  @override
+  Future<void> track(
+    String eventName, {
+    Map<String, Object?> params = const <String, Object?>{},
+  }) async {
+    tracked.add(_Tracked(eventName, Map<String, Object?>.from(params)));
+  }
+
+  @override
+  Future<void> flush({bool force = false}) async {}
+  @override
+  Future<void> close() async {}
+}
+
+class _Tracked {
+  const _Tracked(this.name, this.params);
+  final String name;
+  final Map<String, Object?> params;
+}

--- a/docs/DOCS_CHANGELOG.md
+++ b/docs/DOCS_CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Append one dated line per status-changing documentation merge. The canonical status of the product is [roadmap/05_IMPLEMENTATION_STATUS.md](roadmap/05_IMPLEMENTATION_STATUS.md); this log records *when and why* it (and other load-bearing docs) changed. Supersedes the archived `archive/root/DOCS_CHANGELOG_2026-02-26.md`.
 
+## 2026-06-21 (Match-3 "Три в ряд" — Phase 2)
+- Shipped the third game on the shared meta-layer (per [architecture/04_MULTI_GAME_ENGINE_PLAN.md](architecture/04_MULTI_GAME_ENGINE_PLAN.md) / ADR-002), reachable from a new "Play Match 3" button on the home screen.
+- **Domain core** (`lib/domain/match3/`, pure Dart): `TileGrid`, `MatchDetector` (H/V runs of 3+ with de-duplicated union), `SwapValidator` (adjacency + revert-on-no-match), `TileSpawner` (seeded, no-pre-existing-match fill + refill), `CascadeResolver` (deterministic clear→gravity→refill→re-detect with per-step records), `Match3Scoring` (per-tile × cascade multiplier + 4/5-run bonuses), `Match3Engine` (move-limited run, no-moves reshuffle, events, snapshot/restore). Special tiles (line/bomb gems) intentionally deferred — the detonation matrix is the top clone-bug risk.
+- **Presentation:** `Match3Controller` (engine ↔ SFX/haptics/analytics, resume snapshot + best score via `Match3SessionStore`), `Match3FlameGame` (gem render + selection + clear/cascade juice: particles, flash, combo pulse, "+N" score pops), `Match3Screen` (tap-to-select / tap-adjacent and swipe input, lifecycle persistence, game-over card). DI-registered; analytics emit `game_id:'match3'` (schema gained `cascade` on `line_clear`, `moves_used` on `game_end`, `resumed` on `game_start`).
+- `flutter analyze` clean; **196 tests** (+33: 29 domain incl. a constructed 2-deep cascade, +4 controller wiring).
+
 ## 2026-06-21 (Review follow-ups — batch 1)
 - Closed the 4 priority follow-ups from the PR #42 review: (1) billing token binding is now atomic (check inside `runTransaction` in `verifyPurchase`); (2) `game_end` de-duplicated per round in both Tetris and Classic (`_gameEndEmitted` guard); (3) mid-clear snapshot no longer loses the lock/score (`TetrisEngine.flushPendingClear` invoked from `saveActiveGame`); (4) Tetris teardown hardened (controller `_disposed` guard + `onVisualEvent` cleared + Flame loop paused on dispose). `flutter analyze` clean; 163 tests. Details: [audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md](audit/03_GAMEFEEL_REVIEW_FOLLOWUPS_2026-06-21.md).
 


### PR DESCRIPTION
## Summary
Adds **Match-3 ("Три в ряд")** as the third game, alongside Classic and Tetris, per the multi-game plan (ADR-002). It plugs into the existing meta-layer (DI, analytics, audio/haptics, persistence, Flame shell) without forking it — reachable from a new **Play Match 3** button on the home screen.

Two commits: a pure-domain core (with tests) first, then presentation + wiring.

### Domain core (`lib/domain/match3/`, Flutter-independent)
- **TileGrid** — W×H board of `TileColor?` (mirrors `TetrisBoard`); immutable swap/clear ops; JSON round-trip.
- **MatchDetector** — maximal horizontal/vertical runs of 3+, de-duplicated union for L/T shapes, cheap `hasMatch`.
- **SwapValidator** — orthogonal adjacency + "revert on no-match".
- **TileSpawner** — seeded/deterministic; initial fill guarantees no pre-existing match; refill fills post-gravity holes.
- **CascadeResolver** — deterministic clear → gravity → refill → re-detect loop with a per-step record (cleared cells + colors, cascade level, run length, score).
- **Match3Scoring** — per-tile base × cascade multiplier + 4/5-run bonuses.
- **Match3Engine** — move-limited run; swap input, cascade resolution, no-moves reshuffle, events, snapshot/restore, `findHint`.

Special tiles (line/bomb gems) are **intentionally deferred** — the plan flags the special×special detonation matrix as the top clone-bug risk, so the plain-tile state machine is locked down with tests first.

### Presentation
- **Match3Controller** — engine ↔ SFX/haptics/analytics; resume snapshot + best score via `Match3SessionStore`; move-only (no clock); disposed-guarded; `game_end` de-duped per round.
- **Match3FlameGame** — gem render + selection highlight + juice (shared `BurstField` particles, board flash, COMBO/SHUFFLE pulses, floating "+N" pops). Tap-to-select / tap-adjacent **and** swipe.
- **Match3Screen** — HUD (score/best/moves), square board, gesture input, lifecycle persistence, game-over card.
- DI registers `Match3SessionStore`; analytics emit `game_id:'match3'` (schema gained `cascade`, `moves_used`, `resumed`).

## Tests
`flutter analyze` clean; **196 tests pass** (+33: 29 domain incl. a hand-constructed 2-deep cascade, +4 controller wiring).

Details: `docs/DOCS_CHANGELOG.md` (Match-3 Phase 2 entry).

> Note: branches off `main`; independent of the open batch-2 follow-ups PR (#44) — they touch different files (the only shared file, `analytics_schema_validator.dart`, gets compatible additive edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)